### PR TITLE
Add a lifetime to the BytesEncode trait

### DIFF
--- a/examples/all-types-poly.rs
+++ b/examples/all-types-poly.rs
@@ -127,14 +127,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // or iterate over ranges too!!!
     let range = BEI64::new(35)..=BEI64::new(42);
     let rets: Result<Vec<(BEI64, _)>, _> = db
-        .range::<OwnedType<BEI64>, Unit, _>(&wtxn, range)?
+        .range::<OwnedType<BEI64>, Unit, _>(&wtxn, &range)?
         .collect();
 
     println!("{:?}", rets);
 
     // delete a range of key
     let range = BEI64::new(35)..=BEI64::new(42);
-    let deleted: usize = db.delete_range::<OwnedType<BEI64>, _>(&mut wtxn, range)?;
+    let deleted: usize = db.delete_range::<OwnedType<BEI64>, _>(&mut wtxn, &range)?;
 
     let rets: Result<Vec<(BEI64, _)>, _> = db.iter::<OwnedType<BEI64>, Unit>(&wtxn)?.collect();
 

--- a/examples/all-types.rs
+++ b/examples/all-types.rs
@@ -133,13 +133,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // or iterate over ranges too!!!
     let range = BEI64::new(35)..=BEI64::new(42);
-    let rets: Result<Vec<(BEI64, _)>, _> = db.range(&wtxn, range)?.collect();
+    let rets: Result<Vec<(BEI64, _)>, _> = db.range(&wtxn, &range)?.collect();
 
     println!("{:?}", rets);
 
     // delete a range of key
     let range = BEI64::new(35)..=BEI64::new(42);
-    let deleted: usize = db.delete_range(&mut wtxn, range)?;
+    let deleted: usize = db.delete_range(&mut wtxn, &range)?;
 
     let rets: Result<Vec<(BEI64, _)>, _> = db.iter(&wtxn)?.collect();
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -59,10 +59,10 @@ impl<KC, DC> RwIter<'_, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode,
-        DC: BytesEncode,
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -158,10 +158,10 @@ impl<KC, DC> RwRange<'_, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode,
-        DC: BytesEncode,
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/src/db/uniform.rs
+++ b/src/db/uniform.rs
@@ -85,7 +85,7 @@ use crate::*;
 ///
 /// // you can iterate over ranges too!!!
 /// let range = BEI64::new(35)..=BEI64::new(42);
-/// let rets: Result<_, _> = db.range(&wtxn, range)?.collect();
+/// let rets: Result<_, _> = db.range(&wtxn, &range)?.collect();
 /// let rets: Vec<(BEI64, _)> = rets?;
 ///
 /// let expected = vec![
@@ -97,7 +97,7 @@ use crate::*;
 ///
 /// // even delete a range of keys
 /// let range = BEI64::new(35)..=BEI64::new(42);
-/// let deleted: usize = db.delete_range(&mut wtxn, range)?;
+/// let deleted: usize = db.delete_range(&mut wtxn, &range)?;
 ///
 /// let rets: Result<_, _> = db.iter(&wtxn)?.collect();
 /// let rets: Vec<(BEI64, _)> = rets?;
@@ -158,9 +158,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'txn>(&self, txn: &'txn RoTxn, key: &KC::EItem) -> Result<Option<DC::DItem>>
+    pub fn get<'a, 'txn>(&self, txn: &'txn RoTxn, key: &'a KC::EItem) -> Result<Option<DC::DItem>>
     where
-        KC: BytesEncode,
+        KC: BytesEncode<'a>,
         DC: BytesDecode<'txn>,
     {
         self.dyndb.get::<KC, DC>(txn, key)
@@ -452,7 +452,7 @@ impl<KC, DC> Database<KC, DC> {
     /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let mut iter = db.range(&wtxn, range)?;
+    /// let mut iter = db.range(&wtxn, &range)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
     /// assert_eq!(iter.next().transpose()?, None);
@@ -461,9 +461,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range<'txn, R>(&self, txn: &'txn RoTxn, range: R) -> Result<RoRange<'txn, KC, DC>>
+    pub fn range<'a, 'txn, R>(&self, txn: &'txn RoTxn, range: &'a R) -> Result<RoRange<'txn, KC, DC>>
     where
-        KC: BytesEncode,
+        KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
     {
         self.dyndb.range::<KC, DC, R>(txn, range)
@@ -499,7 +499,7 @@ impl<KC, DC> Database<KC, DC> {
     /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let mut range = db.range_mut(&mut wtxn, range)?;
+    /// let mut range = db.range_mut(&mut wtxn, &range)?;
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// let ret = range.del_current()?;
     /// assert!(ret);
@@ -521,13 +521,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range_mut<'txn, R>(
+    pub fn range_mut<'a, 'txn, R>(
         &self,
         txn: &'txn mut RwTxn,
-        range: R,
+        range: &'a R,
     ) -> Result<RwRange<'txn, KC, DC>>
     where
-        KC: BytesEncode,
+        KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
     {
         self.dyndb.range_mut::<KC, DC, R>(txn, range)
@@ -573,13 +573,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter<'txn>(
+    pub fn prefix_iter<'a, 'txn>(
         &self,
         txn: &'txn RoTxn,
-        prefix: &KC::EItem,
+        prefix: &'a KC::EItem,
     ) -> Result<RoRange<'txn, KC, DC>>
     where
-        KC: BytesEncode,
+        KC: BytesEncode<'a>,
     {
         self.dyndb.prefix_iter::<KC, DC>(txn, prefix)
     }
@@ -637,13 +637,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter_mut<'txn>(
+    pub fn prefix_iter_mut<'a, 'txn>(
         &self,
         txn: &'txn RwTxn,
-        prefix: &KC::EItem,
+        prefix: &'a KC::EItem,
     ) -> Result<RwRange<'txn, KC, DC>>
     where
-        KC: BytesEncode,
+        KC: BytesEncode<'a>,
     {
         self.dyndb.prefix_iter_mut::<KC, DC>(txn, prefix)
     }
@@ -680,10 +680,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn put(&self, txn: &mut RwTxn, key: &KC::EItem, data: &DC::EItem) -> Result<()>
+    pub fn put<'a>(&self, txn: &mut RwTxn, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
     where
-        KC: BytesEncode,
-        DC: BytesEncode,
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a>,
     {
         self.dyndb.put::<KC, DC>(txn, key, data)
     }
@@ -728,9 +728,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete(&self, txn: &mut RwTxn, key: &KC::EItem) -> Result<bool>
+    pub fn delete<'a>(&self, txn: &mut RwTxn, key: &'a KC::EItem) -> Result<bool>
     where
-        KC: BytesEncode,
+        KC: BytesEncode<'a>,
     {
         self.dyndb.delete::<KC>(txn, key)
     }
@@ -769,7 +769,7 @@ impl<KC, DC> Database<KC, DC> {
     /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let ret = db.delete_range(&mut wtxn, range)?;
+    /// let ret = db.delete_range(&mut wtxn, &range)?;
     /// assert_eq!(ret, 2);
     ///
     ///
@@ -782,9 +782,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete_range<'txn, R>(&self, txn: &'txn mut RwTxn, range: R) -> Result<usize>
+    pub fn delete_range<'a, 'txn, R>(&self, txn: &'txn mut RwTxn, range: &'a R) -> Result<usize>
     where
-        KC: BytesEncode + BytesDecode<'txn>,
+        KC: BytesEncode<'a> + BytesDecode<'txn>,
         R: RangeBounds<KC::EItem>,
     {
         self.dyndb.delete_range::<KC, R>(txn, range)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-pub trait BytesEncode {
-    type EItem: ?Sized;
+pub trait BytesEncode<'a> {
+    type EItem: ?Sized + 'a;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>>;
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<'a, [u8]>>;
 }
 
 pub trait BytesDecode<'a> {

--- a/src/types/cow_slice.rs
+++ b/src/types/cow_slice.rs
@@ -22,13 +22,13 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 /// [`OwnedSlice`]: crate::types::OwnedSlice
 pub struct CowSlice<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for CowSlice<T>
+impl<'a, T: 'a> BytesEncode<'a> for CowSlice<T>
 where
     T: AsBytes,
 {
     type EItem = [T];
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
     }
 }

--- a/src/types/cow_type.rs
+++ b/src/types/cow_type.rs
@@ -28,13 +28,13 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 /// [`CowSlice`]: crate::types::CowSlice
 pub struct CowType<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for CowType<T>
+impl<'a, T: 'a> BytesEncode<'a> for CowType<T>
 where
     T: AsBytes,
 {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(<T as AsBytes>::as_bytes(item)))
     }
 }

--- a/src/types/owned_slice.rs
+++ b/src/types/owned_slice.rs
@@ -20,13 +20,13 @@ use crate::{BytesDecode, BytesEncode};
 /// [`CowType`]: crate::types::CowType
 pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for OwnedSlice<T>
+impl<'a, T: 'a> BytesEncode<'a> for OwnedSlice<T>
 where
     T: AsBytes,
 {
     type EItem = [T];
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
     }
 }

--- a/src/types/owned_type.rs
+++ b/src/types/owned_type.rs
@@ -25,13 +25,13 @@ use zerocopy::{AsBytes, FromBytes};
 /// [`CowSlice`]: crate::types::CowSlice
 pub struct OwnedType<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for OwnedType<T>
+impl<'a, T: 'a> BytesEncode<'a> for OwnedType<T>
 where
     T: AsBytes,
 {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(<T as AsBytes>::as_bytes(item)))
     }
 }

--- a/src/types/serde_bincode.rs
+++ b/src/types/serde_bincode.rs
@@ -7,13 +7,13 @@ use std::borrow::Cow;
 /// It can borrow bytes from the original slice.
 pub struct SerdeBincode<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for SerdeBincode<T>
+impl<'a, T: 'a> BytesEncode<'a> for SerdeBincode<T>
 where
     T: Serialize,
 {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         bincode::serialize(item).map(Cow::Owned).ok()
     }
 }

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 /// It can borrow bytes from the original slice.
 pub struct SerdeJson<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for SerdeJson<T>
+impl<'a, T: 'a> BytesEncode<'a> for SerdeJson<T>
 where
     T: Serialize,
 {

--- a/src/types/str.rs
+++ b/src/types/str.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 /// Describes an [`str`].
 pub struct Str;
 
-impl BytesEncode for Str {
+impl BytesEncode<'_> for Str {
     type EItem = str;
 
     fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {

--- a/src/types/unaligned_slice.rs
+++ b/src/types/unaligned_slice.rs
@@ -13,13 +13,13 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};
 /// [`CowType`]: crate::types::CowType
 pub struct UnalignedSlice<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for UnalignedSlice<T>
+impl<'a, T: 'a> BytesEncode<'a> for UnalignedSlice<T>
 where
     T: AsBytes + Unaligned,
 {
     type EItem = [T];
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
     }
 }

--- a/src/types/unaligned_type.rs
+++ b/src/types/unaligned_type.rs
@@ -19,13 +19,13 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};
 /// [`CowSlice`]: crate::types::CowSlice
 pub struct UnalignedType<T>(std::marker::PhantomData<T>);
 
-impl<T> BytesEncode for UnalignedType<T>
+impl<'a, T: 'a> BytesEncode<'a> for UnalignedType<T>
 where
     T: AsBytes + Unaligned,
 {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(<T as AsBytes>::as_bytes(item)))
     }
 }

--- a/src/types/unit.rs
+++ b/src/types/unit.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 /// [unit `()`]: https://doc.rust-lang.org/std/primitive.unit.html
 pub struct Unit;
 
-impl BytesEncode for Unit {
+impl BytesEncode<'_> for Unit {
     type EItem = ();
 
     fn bytes_encode(_item: &Self::EItem) -> Option<Cow<[u8]>> {


### PR DESCRIPTION
Adding this lifetime constraint seems bizarre but it allows to encode types that are bound to lifetimes. We are now able to accept an `EItem` that is bounded by lifetimes and return its borrowed data which wasn't possible before.

```rust
struct MyLifetimeBoundedStruct<'a>(&'a [u8]);

impl<'a> BytesEncode<'a> for MyCodec {
    type EItem = MyLifetimeBoundedStruct<'a>;

    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<'a, [u8]>> {
        Some(Cow::Borrowed(item.0))
    }
}
```