### PR TITLE
Expose the DecodeIgnore type

### DIFF
--- a/src/db/polymorph.rs
+++ b/src/db/polymorph.rs
@@ -144,7 +144,11 @@ impl PolyDatabase {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'a, 'txn, KC, DC>(&self, txn: &'txn RoTxn, key: &'a KC::EItem) -> Result<Option<DC::DItem>>
+    pub fn get<'a, 'txn, KC, DC>(
+        &self,
+        txn: &'txn RoTxn,
+        key: &'a KC::EItem,
+    ) -> Result<Option<DC::DItem>>
     where
         KC: BytesEncode<'a>,
         DC: BytesDecode<'txn>,
@@ -820,7 +824,12 @@ impl PolyDatabase {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn put<'a, KC, DC>(&self, txn: &mut RwTxn, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn put<'a, KC, DC>(
+        &self,
+        txn: &mut RwTxn,
+        key: &'a KC::EItem,
+        data: &'a DC::EItem,
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         DC: BytesEncode<'a>,

--- a/src/db/polymorph.rs
+++ b/src/db/polymorph.rs
@@ -6,6 +6,7 @@ use lmdb_sys as ffi;
 
 use super::advance_key;
 use crate::lmdb_error::lmdb_result;
+use crate::types::DecodeIgnore;
 use crate::*;
 
 /// A polymorphic database that accepts types on call methods and not at creation.
@@ -959,18 +960,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a> + BytesDecode<'txn>,
         R: RangeBounds<KC::EItem>,
     {
-        struct Ignore;
-
-        impl BytesDecode<'_> for Ignore {
-            type DItem = ();
-
-            fn bytes_decode(_bytes: &[u8]) -> Option<Self::DItem> {
-                Some(())
-            }
-        }
-
         let mut count = 0;
-        let mut iter = self.range_mut::<KC, Ignore, _>(txn, range)?;
+        let mut iter = self.range_mut::<KC, DecodeIgnore, _>(txn, range)?;
 
         while let Some(_) = iter.next() {
             iter.del_current()?;

--- a/src/db/uniform.rs
+++ b/src/db/uniform.rs
@@ -461,7 +461,11 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range<'a, 'txn, R>(&self, txn: &'txn RoTxn, range: &'a R) -> Result<RoRange<'txn, KC, DC>>
+    pub fn range<'a, 'txn, R>(
+        &self,
+        txn: &'txn RoTxn,
+        range: &'a R,
+    ) -> Result<RoRange<'txn, KC, DC>>
     where
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -73,6 +73,20 @@ pub use self::unit::Unit;
 /// [memory alignment]: https://doc.rust-lang.org/std/mem/fn.align_of.html
 pub type ByteSlice = UnalignedSlice<u8>;
 
+/// A convenient struct made to ignore the type when decoding it.
+///
+/// It is appropriate to be used to count keys for example
+/// or to ensure that an entry exist for example.
+pub struct DecodeIgnore;
+
+impl crate::traits::BytesDecode<'_> for DecodeIgnore {
+    type DItem = ();
+
+    fn bytes_decode(_bytes: &[u8]) -> Option<Self::DItem> {
+        Some(())
+    }
+}
+
 #[cfg(feature = "serde-bincode")]
 pub use self::serde_bincode::SerdeBincode;
 


### PR DESCRIPTION
Expose a type that is made to help ignore entries and let you avoid have decoding errors.
Useful when you just want to know if a key exists or count the number or elements a ranges returns.