### PR TITLE
Introduce nested transactions

### DIFF
--- a/examples/unsafe-nested.rs
+++ b/examples/unsafe-nested.rs
@@ -1,0 +1,63 @@
+use std::error::Error;
+use std::fs;
+
+use heed::types::*;
+use heed::{Database, EnvOpenOptions};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all("target/zerocopy.mdb")?;
+
+    let env = EnvOpenOptions::new()
+        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .max_dbs(3000)
+        .open("target/zerocopy.mdb")?;
+
+    // here the key will be an str and the data will be a slice of u8
+    let db: Database<Str, ByteSlice> = env.create_database(Some("kiki"))?;
+
+    let grtxn = env.read_txn()?;
+    let mut wtxn = env.write_txn()?;
+
+    db.put(&mut wtxn, "hello", &[2, 3][..])?;
+
+    let ret = db.get(&wtxn, "hello")?;
+    println!("parent \"hello\": {:?}", ret);
+
+    let mut nwtxn = unsafe { env.nested_write_txn(&wtxn)? };
+
+    db.put(&mut nwtxn, "what", &[4, 5][..])?;
+    let ret = db.get(&nwtxn, "what")?;
+    println!("nested(1) \"what\": {:?}", ret);
+
+    println!("nested(1) abort");
+    nwtxn.abort();
+
+    let ret = db.get(&wtxn, "what")?;
+    println!("nested(1) \"what\": {:?}", ret);
+
+    let mut nwtxn = unsafe { env.nested_write_txn(&wtxn)? };
+
+    db.put(&mut nwtxn, "humm...", &[6, 7][..])?;
+    let ret = db.get(&nwtxn, "humm...")?;
+    println!("nested(2) \"humm...\": {:?}", ret);
+
+    println!("nested(2) commit");
+    nwtxn.commit()?;
+
+    let ret = db.get(&grtxn, "humm...")?;
+    println!("parent rtxn \"humm...\": {:?}", ret);
+    grtxn.abort();
+
+    let ret = db.get(&wtxn, "humm...")?;
+    println!("nested(2) \"humm...\": {:?}", ret);
+
+    println!("parent commit");
+    wtxn.commit()?;
+
+    let rtxn = env.read_txn()?;
+
+    let ret = db.get(&rtxn, "hello")?;
+    println!("parent \"hello\": {:?}", ret);
+
+    Ok(())
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -288,6 +288,10 @@ impl Env {
         RwTxn::new(self.0.env)
     }
 
+    pub unsafe fn nested_write_txn(&self, parent: &RwTxn) -> Result<RwTxn> {
+        RwTxn::new_nested(self.0.env, parent)
+    }
+
     pub fn read_txn(&self) -> Result<RoTxn> {
         RoTxn::new(self.0.env)
     }

--- a/src/txn.rs
+++ b/src/txn.rs
@@ -58,13 +58,20 @@ impl RwTxn {
         Ok(RwTxn { txn: RoTxn { txn } })
     }
 
+    pub(crate) unsafe fn new_nested(env: *mut ffi::MDB_env, parent: &RwTxn) -> Result<RwTxn> {
+        let mut txn: *mut ffi::MDB_txn = ptr::null_mut();
+        let parent_ptr: *mut ffi::MDB_txn = parent.txn.txn;
+
+        lmdb_result(ffi::mdb_txn_begin(env, parent_ptr, 0, &mut txn))?;
+
+        Ok(RwTxn { txn: RoTxn { txn } })
+    }
+
     pub fn commit(self) -> Result<()> {
         self.txn.commit()
     }
 
-    pub fn abort(self) {
-        drop(self.txn)
-    }
+    pub fn abort(self) {}
 }
 
 impl Deref for RwTxn {


### PR DESCRIPTION
Those are unsafe until I find a good abstraction to them. I thought of some ones:
  - create a `NestedRwTxn` that can be derefed to `Rw/RoTxn`.
  - or we can make the current `RwTxn<'p>` always have a lifetime to a parent and make it `'static` when it is the master transaction.

Currently we must never do anything else than abort or commit the parent transaction when it have active children (nested) transactions (i.e. no key writes).