### PR TITLE
Support windows and make the tests pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ serde = { version = "1.0.101", optional = true }
 serde_json = { version = "1.0.41", optional = true }
 zerocopy = "0.2.8"
 
+[target.'cfg(windows)'.dependencies]
+url = "2.1.0"
+
 [dev-dependencies]
 serde = { version = "1.0.101", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 [dependencies]
 bincode = { version = "1.2.0", optional = true }
 byteorder = { version = "1.3", default-features = false }
-lmdb-rkv-sys = "0.9.5"
 libc = "0.2.62"
+lmdb-rkv-sys = "0.10.0"
 once_cell = "1.2.0"
 page_size = "0.4.1"
 serde = { version = "1.0.101", optional = true }

--- a/examples/all-types-poly.rs
+++ b/examples/all-types-poly.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::fs;
+use std::path::Path;
 
 use heed::byteorder::BE;
 use heed::types::*;
@@ -8,12 +9,12 @@ use heed::EnvOpenOptions;
 use serde::{Deserialize, Serialize};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    fs::create_dir_all("target/zerocopy-dyn.mdb")?;
+    fs::create_dir_all(Path::new("target").join("zerocopy-dyn.mdb"))?;
 
     let env = EnvOpenOptions::new()
         .map_size(10 * 1024 * 1024 * 1024) // 10GB
         .max_dbs(3000)
-        .open("target/zerocopy-dyn.mdb")?;
+        .open(Path::new("target").join("zerocopy-dyn.mdb"))?;
 
     // you can specify that a database will support some typed key/data
     //

--- a/examples/all-types.rs
+++ b/examples/all-types.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::fs;
+use std::path::Path;
 
 use heed::byteorder::BE;
 use heed::types::*;
@@ -8,12 +9,12 @@ use heed::{Database, EnvOpenOptions};
 use serde::{Deserialize, Serialize};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    fs::create_dir_all("target/zerocopy.mdb")?;
+    fs::create_dir_all(Path::new("target").join("zerocopy-dyn.mdb"))?;
 
     let env = EnvOpenOptions::new()
         .map_size(10 * 1024 * 1024 * 1024) // 10GB
         .max_dbs(3000)
-        .open("target/zerocopy.mdb")?;
+        .open(Path::new("target").join("zerocopy.mdb"))?;
 
     // you can specify that a database will support some typed key/data
     //

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,16 +1,17 @@
 use std::error::Error;
 use std::fs;
+use std::path::Path;
 
 use heed::types::*;
 use heed::{Database, EnvOpenOptions};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    fs::create_dir_all("target/zerocopy.mdb")?;
+    fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 
     let env = EnvOpenOptions::new()
         .map_size(10 * 1024 * 1024 * 1024) // 10GB
         .max_dbs(3000)
-        .open("target/zerocopy.mdb")?;
+        .open(Path::new("target").join("zerocopy.mdb"))?;
 
     // here the key will be an str and the data will be a slice of u8
     let db: Database<Str, ByteSlice> = env.create_database(None)?;

--- a/src/db/polymorph.rs
+++ b/src/db/polymorph.rs
@@ -19,17 +19,18 @@ use crate::*;
 ///
 /// ```
 /// # use std::fs;
+/// # use std::path::Path;
 /// # use heed::EnvOpenOptions;
 /// use heed::PolyDatabase;
 /// use heed::types::*;
 /// use heed::{zerocopy::I64, byteorder::BigEndian};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # fs::create_dir_all("target/zerocopy.mdb")?;
+/// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
 /// #     .max_dbs(3000)
-/// #     .open("target/zerocopy.mdb")?;
+/// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let db: PolyDatabase = env.create_poly_database(Some("big-endian-iter"))?;
@@ -61,17 +62,18 @@ use crate::*;
 ///
 /// ```
 /// # use std::fs;
+/// # use std::path::Path;
 /// # use heed::EnvOpenOptions;
 /// use heed::PolyDatabase;
 /// use heed::types::*;
 /// use heed::{zerocopy::I64, byteorder::BigEndian};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # fs::create_dir_all("target/zerocopy.mdb")?;
+/// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
 /// #     .max_dbs(3000)
-/// #     .open("target/zerocopy.mdb")?;
+/// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let db: PolyDatabase = env.create_poly_database(Some("big-endian-iter"))?;
@@ -118,16 +120,17 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// let db = env.create_poly_database(Some("get-poly-i32"))?;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -186,17 +189,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("first-poly-i32"))?;
@@ -236,17 +240,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("last-i32"))?;
@@ -282,17 +287,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -335,17 +341,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -380,17 +387,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -423,17 +431,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -481,17 +490,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -561,17 +571,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -654,17 +665,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -720,17 +732,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -796,17 +809,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -860,17 +874,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -928,17 +943,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;
@@ -989,17 +1005,18 @@ impl PolyDatabase {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db = env.create_poly_database(Some("iter-i32"))?;

--- a/src/db/uniform.rs
+++ b/src/db/uniform.rs
@@ -15,17 +15,18 @@ use crate::*;
 ///
 /// ```
 /// # use std::fs;
+/// # use std::path::Path;
 /// # use heed::EnvOpenOptions;
 /// use heed::Database;
 /// use heed::types::*;
 /// use heed::{zerocopy::I64, byteorder::BigEndian};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # fs::create_dir_all("target/zerocopy.mdb")?;
+/// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
 /// #     .max_dbs(3000)
-/// #     .open("target/zerocopy.mdb")?;
+/// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
@@ -61,17 +62,18 @@ use crate::*;
 ///
 /// ```
 /// # use std::fs;
+/// # use std::path::Path;
 /// # use heed::EnvOpenOptions;
 /// use heed::Database;
 /// use heed::types::*;
 /// use heed::{zerocopy::I64, byteorder::BigEndian};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # fs::create_dir_all("target/zerocopy.mdb")?;
+/// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
 /// #     .max_dbs(3000)
-/// #     .open("target/zerocopy.mdb")?;
+/// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
@@ -132,16 +134,17 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// let db: Database<Str, OwnedType<i32>> = env.create_database(Some("get-i32"))?;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -174,17 +177,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("first-i32"))?;
@@ -216,17 +220,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("last-i32"))?;
@@ -254,17 +259,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -295,17 +301,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -336,17 +343,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -375,17 +383,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -429,17 +438,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -480,17 +490,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -544,17 +555,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
@@ -595,17 +607,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
@@ -656,17 +669,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -698,17 +712,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -750,17 +765,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -803,17 +819,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// ```
     /// # use std::fs;
+    /// # use std::path::Path;
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
     /// use heed::{zerocopy::I32, byteorder::BigEndian};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all("target/zerocopy.mdb")?;
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
     /// #     .max_dbs(3000)
-    /// #     .open("target/zerocopy.mdb")?;
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;

--- a/src/env.rs
+++ b/src/env.rs
@@ -59,18 +59,19 @@ impl EnvOpenOptions {
     /// Set one or more LMDB flags (see http://www.lmdb.tech/doc/group__mdb__env.html).
     /// ```
     /// use std::fs;
+    /// use std::path::Path;
     /// use heed::{EnvOpenOptions, Database};
     /// use heed::types::*;
     /// use heed::flags::Flags;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// fs::create_dir_all("target/zerocopy.mdb")?;
+    /// fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// let mut env_builder = EnvOpenOptions::new();
     /// unsafe {
     ///     env_builder.flag(Flags::MdbNoSync);
     ///     env_builder.flag(Flags::MdbNoMetaSync);
     /// }
-    /// let env = env_builder.open("target/zerocopy.mdb")?;
+    /// let env = env_builder.open(Path::new("target").join("zerocopy.mdb"))?;
     ///
     /// // we will open the default unamed database
     /// let db: Database<Str, OwnedType<i32>> = env.create_database(None)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,13 @@
 //!
 //! ```
 //! use std::fs;
+//! use std::path::Path;
 //! use heed::{EnvOpenOptions, Database};
 //! use heed::types::*;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! fs::create_dir_all("target/zerocopy.mdb")?;
-//! let env = EnvOpenOptions::new().open("target/zerocopy.mdb")?;
+//! fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+//! let env = EnvOpenOptions::new().open(Path::new("target").join("zerocopy.mdb"))?;
 //!
 //! // we will open the default unamed database
 //! let db: Database<Str, OwnedType<i32>> = env.create_database(None)?;


### PR DESCRIPTION
Hello potential contributor,

I am currently working on making [MeiliSearch](https://github.com/meilisearch/MeiliSearch) compile on Windows. The only remaining dependency to update seems to be heed.
In this pull request I use [a fork of the lmdb-sys crate](https://github.com/mozilla/lmdb-rs/compare/master...Kerollmops:support-windows-filehandle) that seems to compile on Windows. The issue is that even with this fork I am not able to find where I am wrong and why I get [this error message](https://github.com/Kerollmops/heed/runs/321172595#step:4:113). I don't have a Windows computer at hand and would be glad if someone could help me tackle this :)

Will be fixed when https://github.com/mozilla/lmdb-rs/pull/74 is merged.

Closes #24.