### PR TITLE
Fix increase sequence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,14 @@ jobs:
 
       # Test the LMDB backend
       - name: Run cargo test LMDB
-        uses: actions-rs/cargo@v1
-        with:
-          run: cd heed && cargo test --features 'lmdb serde-json' --no-default-features
+        run: |
+          cd heed
+          cargo clean
+          cargo test --features 'lmdb serde-json' --no-default-features
 
       # Test the MDBX backend
       - name: Run cargo test MDBX
-        uses: actions-rs/cargo@v1
-        with:
-          run: cd heed && cargo test --features 'mdbx serde-json' --no-default-features
+        run: |
+          cd heed
+          cargo clean
+          cargo test --features 'mdbx serde-json' --no-default-features

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -216,7 +216,7 @@ impl PolyDatabase {
 
         let result = unsafe {
             mdb_result(ffi::mdbx_dbi_sequence(
-                txn.txn,
+                txn.txn.txn,
                 self.dbi,
                 value.as_mut_ptr(),
                 increment,

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -33,8 +33,10 @@ impl<T> RoTxn<T> {
         result.map_err(Into::into)
     }
 
-    pub fn abort(self) -> Result<()> {
-        abort_txn(self.txn)
+    pub fn abort(mut self) -> Result<()> {
+        abort_txn(self.txn)?;
+        self.txn = ptr::null_mut();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR fixes the project when executed setup for MDBX, the Github Action [were not running correctly but were showing a validation symbol](https://github.com/Kerollmops/heed/runs/696297056#step:5:1). I fixed those in this PR.

This CI problem shows another, way more important, problem: aborted transactions were not correctly implemented and resulted in double abortion.

Fixes #45