### PR TITLE
Bump heed version to 0.8.0

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "heed"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
-description = "A fully typed LMDB wrapper with minimum overhead"
+description = "A fully typed LMDB/MDBX wrapper with minimum overhead"
 license = "MIT"
 repository = "https://github.com/Kerollmops/heed"
 keywords = ["lmdb", "database", "storage", "typed"]


### PR DESCRIPTION
I yanked the version 0.7.2 because it contained breaking changes and release a new 0.8.0 version.