### PR TITLE
Introduce the RwIter append method

### DIFF
--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -1,0 +1,42 @@
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use heed::types::*;
+use heed::{Database, EnvOpenOptions};
+
+// In this test we are checking that we can append ordered entries in one
+// database even if there is multiple databases which already contain entries.
+fn main() -> Result<(), Box<dyn Error>> {
+    let env_path = Path::new("target").join("env1.mdb");
+
+    let _ = fs::remove_dir_all(&env_path);
+
+    fs::create_dir_all(&env_path)?;
+    let env = EnvOpenOptions::new()
+        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .max_dbs(3)
+        .open(env_path)?;
+
+    let first: Database<Str, Str> = env.create_database(Some("first"))?;
+    let second: Database<Str, Str> = env.create_database(Some("second"))?;
+
+    let mut wtxn = env.write_txn()?;
+
+    // We fill the first database with entries.
+    first.put(&mut wtxn, "I am here", "to test things")?;
+    first.put(&mut wtxn, "I am here too", "for the same purpose")?;
+
+    // We try to append ordered entries in the second database.
+    let mut iter = second.iter_mut(&mut wtxn)?;
+
+    iter.append("aaaa", "lol")?;
+    iter.append("abcd", "lol")?;
+    iter.append("bcde", "lol")?;
+
+    drop(iter);
+
+    wtxn.commit()?;
+
+    Ok(())
+}

--- a/heed/src/db/mod.rs
+++ b/heed/src/db/mod.rs
@@ -68,6 +68,16 @@ impl<KC, DC> RwIter<'_, KC, DC> {
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
+
+    pub fn append<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    where
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
+        self.cursor.append(&key_bytes, &data_bytes)
+    }
 }
 
 impl<'txn, KC, DC> Iterator for RwIter<'txn, KC, DC>

--- a/heed/src/db/mod.rs
+++ b/heed/src/db/mod.rs
@@ -55,10 +55,20 @@ pub struct RwIter<'txn, KC, DC> {
 }
 
 impl<KC, DC> RwIter<'_, KC, DC> {
+    /// Delete the entry the cursor is currently pointing to.
+    ///
+    /// Returns `true` if the entry was successfully deleted.
     pub fn del_current(&mut self) -> Result<bool> {
         self.cursor.del_current()
     }
 
+    /// Write a new value to the current entry.
+    /// The given key must be equal to the one this cursor is pointing at.
+    ///
+    /// Returns `true` if the entry was successfully written.
+    ///
+    /// This is intended to be used when the new data is the same size as the old.
+    /// Otherwise it will simply perform a delete of the old record followed by an insert.
     pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
     where
         KC: BytesEncode<'a>,
@@ -69,6 +79,10 @@ impl<KC, DC> RwIter<'_, KC, DC> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
+    /// Append the given key/value pair to the end of the database.
+    ///
+    /// If a key is inserted that is less than any previous key a `KeyExist` error
+    /// is returned and the key is not inserted into the database.
     pub fn append<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
     where
         KC: BytesEncode<'a>,


### PR DESCRIPTION
This method can be used to faster bulk load key/value pairs when you know those are already ordered.

LMDB will avoid splitting B+Tree nodes in half and instead create a new node at the tail of the current one and also skip key comparisons.

http://www.lmdb.tech/doc/group__mdb.html#ga1f83ccb40011837ff37cc32be01ad91e