### PR TITLE
Mark every codec Send + Sync

### DIFF
--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -66,3 +66,7 @@ where
         }
     }
 }
+
+unsafe impl<T> Send for CowSlice<T> {}
+
+unsafe impl<T> Sync for CowSlice<T> {}

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -69,3 +69,7 @@ where
         }
     }
 }
+
+unsafe impl<T> Send for CowType<T> {}
+
+unsafe impl<T> Sync for CowType<T> {}

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -41,3 +41,7 @@ where
         CowSlice::<T>::bytes_decode(bytes).map(Cow::into_owned)
     }
 }
+
+unsafe impl<T> Send for OwnedSlice<T> {}
+
+unsafe impl<T> Sync for OwnedSlice<T> {}

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -46,3 +46,7 @@ where
         CowType::<T>::bytes_decode(bytes).map(Cow::into_owned)
     }
 }
+
+unsafe impl<T> Send for OwnedType<T> {}
+
+unsafe impl<T> Sync for OwnedType<T> {}

--- a/heed-types/src/serde_bincode.rs
+++ b/heed-types/src/serde_bincode.rs
@@ -28,3 +28,7 @@ where
         bincode::deserialize(bytes).ok()
     }
 }
+
+unsafe impl<T> Send for SerdeBincode<T> {}
+
+unsafe impl<T> Sync for SerdeBincode<T> {}

--- a/heed-types/src/serde_json.rs
+++ b/heed-types/src/serde_json.rs
@@ -28,3 +28,7 @@ where
         serde_json::from_slice(bytes).ok()
     }
 }
+
+unsafe impl<T> Send for SerdeJson<T> {}
+
+unsafe impl<T> Sync for SerdeJson<T> {}

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -34,3 +34,7 @@ where
         LayoutVerified::<_, [T]>::new_slice_unaligned(bytes).map(LayoutVerified::into_slice)
     }
 }
+
+unsafe impl<T> Send for UnalignedSlice<T> {}
+
+unsafe impl<T> Sync for UnalignedSlice<T> {}

--- a/heed-types/src/unaligned_type.rs
+++ b/heed-types/src/unaligned_type.rs
@@ -40,3 +40,7 @@ where
         LayoutVerified::<_, T>::new_unaligned(bytes).map(LayoutVerified::into_ref)
     }
 }
+
+unsafe impl<T> Send for UnalignedType<T> {}
+
+unsafe impl<T> Sync for UnalignedType<T> {}


### PR DESCRIPTION
Codec types doesn't store the `T` type they encode/decode, they only store a `PhantomData` type, this means that there is no Send, Sync restriction relative to the `T` type. It is safe to move or refere to a decode type between threads.