### PR TITLE
Introduce a real prefix iterator

### DIFF
--- a/heed/examples/all-types-poly.rs
+++ b/heed/examples/all-types-poly.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     fs::create_dir_all(&path)?;
 
     let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3000)
         .open(path)?;
 

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     fs::create_dir_all(&path)?;
 
     let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3000)
         .open(path)?;
 

--- a/heed/examples/clear-database.rs
+++ b/heed/examples/clear-database.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fs::create_dir_all(&env_path)?;
     let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3)
         .open(env_path)?;
 

--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fs::create_dir_all(&env_path)?;
     let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3)
         .open(env_path)?;
 

--- a/heed/examples/multi-env.rs
+++ b/heed/examples/multi-env.rs
@@ -11,13 +11,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fs::create_dir_all(&env1_path)?;
     let env1 = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3000)
         .open(env1_path)?;
 
     fs::create_dir_all(&env2_path)?;
     let env2 = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3000)
         .open(env2_path)?;
 

--- a/heed/examples/nested.rs
+++ b/heed/examples/nested.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     fs::create_dir_all(&path)?;
 
     let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024 * 1024) // 10GB
+        .map_size(10 * 1024 * 1024) // 10MB
         .max_dbs(3000)
         .open(path)?;
 

--- a/heed/src/db/mod.rs
+++ b/heed/src/db/mod.rs
@@ -341,7 +341,7 @@ mod tests {
 
         fs::create_dir_all(Path::new("target").join("prefix_iter_with_byte_255.mdb")).unwrap();
         let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024 * 1024) // 10GB
+            .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
             .open(Path::new("target").join("prefix_iter_with_byte_255.mdb")).unwrap();
         let db = env.create_database::<ByteSlice, Str>(None).unwrap();

--- a/heed/src/db/mod.rs
+++ b/heed/src/db/mod.rs
@@ -235,3 +235,131 @@ where
         }
     }
 }
+
+pub struct RoPrefix<'txn, KC, DC> {
+    cursor: RoCursor<'txn>,
+    prefix: Vec<u8>,
+    move_on_first: bool,
+    _phantom: marker::PhantomData<(KC, DC)>,
+}
+
+impl<'txn, KC, DC> Iterator for RoPrefix<'txn, KC, DC>
+where
+    KC: BytesDecode<'txn>,
+    DC: BytesDecode<'txn>,
+{
+    type Item = Result<(KC::DItem, DC::DItem)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = if self.move_on_first {
+            self.move_on_first = false;
+            self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix)
+        } else {
+            self.cursor.move_on_next()
+        };
+
+        match result {
+            Ok(Some((key, data))) => {
+                if key.starts_with(&self.prefix) {
+                    match (KC::bytes_decode(key), DC::bytes_decode(data)) {
+                        (Some(key), Some(data)) => Some(Ok((key, data))),
+                        (_, _) => Some(Err(Error::Decoding)),
+                    }
+                } else {
+                    None
+                }
+            },
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+pub struct RwPrefix<'txn, KC, DC> {
+    cursor: RwCursor<'txn>,
+    prefix: Vec<u8>,
+    move_on_first: bool,
+    _phantom: marker::PhantomData<(KC, DC)>,
+}
+
+impl<KC, DC> RwPrefix<'_, KC, DC> {
+    pub fn del_current(&mut self) -> Result<bool> {
+        self.cursor.del_current()
+    }
+
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
+    }
+}
+
+impl<'txn, KC, DC> Iterator for RwPrefix<'txn, KC, DC>
+where
+    KC: BytesDecode<'txn>,
+    DC: BytesDecode<'txn>,
+{
+    type Item = Result<(KC::DItem, DC::DItem)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = if self.move_on_first {
+            self.move_on_first = false;
+            self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix)
+        } else {
+            self.cursor.move_on_next()
+        };
+
+        match result {
+            Ok(Some((key, data))) => {
+                if key.starts_with(&self.prefix) {
+                    match (KC::bytes_decode(key), DC::bytes_decode(data)) {
+                        (Some(key), Some(data)) => Some(Ok((key, data))),
+                        (_, _) => Some(Err(Error::Decoding)),
+                    }
+                } else {
+                    None
+                }
+            },
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn prefix_iter_with_byte_255() {
+        use std::fs;
+        use std::path::Path;
+        use crate::EnvOpenOptions;
+        use crate::types::*;
+
+        fs::create_dir_all(Path::new("target").join("prefix_iter_with_byte_255.mdb")).unwrap();
+        let env = EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024 * 1024) // 10GB
+            .max_dbs(3000)
+            .open(Path::new("target").join("prefix_iter_with_byte_255.mdb")).unwrap();
+        let db = env.create_database::<ByteSlice, Str>(None).unwrap();
+
+        // Create an ordered list of keys...
+        let mut wtxn = env.write_txn().unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], "world").unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], "hello").unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], "world").unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0, 119, 111, 114, 108, 100], "world").unwrap();
+
+        // Lets check that we can prefix_iter on that sequence with the key "255".
+        let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0u8, 0, 0, 255, 104, 101, 108, 108, 111][..], "hello")));
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], "world")));
+        assert_eq!(iter.next().transpose().unwrap(), None);
+        drop(iter);
+
+        wtxn.abort().unwrap();
+    }
+}

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -26,7 +26,7 @@ use crate::types::DecodeIgnore;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
-/// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+/// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
@@ -69,7 +69,7 @@ use crate::types::DecodeIgnore;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
-/// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+/// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
@@ -126,7 +126,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// let db = env.create_poly_database(Some("use-sequence-1"))?;
@@ -189,7 +189,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// let db = env.create_poly_database(Some("use-sequence-2"))?;
@@ -243,7 +243,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// let db = env.create_poly_database(Some("get-poly-i32"))?;
@@ -313,7 +313,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -364,7 +364,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -411,7 +411,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -465,7 +465,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -511,7 +511,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -555,7 +555,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -614,7 +614,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -695,7 +695,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -789,7 +789,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -849,7 +849,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -919,7 +919,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -985,7 +985,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -1050,7 +1050,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -1119,7 +1119,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -1181,7 +1181,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -1228,7 +1228,7 @@ impl PolyDatabase {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -615,7 +615,7 @@ impl<KC, DC> Database<KC, DC> {
         &self,
         txn: &'txn RoTxn<T>,
         prefix: &'a KC::EItem,
-    ) -> Result<RoRange<'txn, KC, DC>>
+    ) -> Result<RoPrefix<'txn, KC, DC>>
     where
         KC: BytesEncode<'a>,
     {
@@ -680,7 +680,7 @@ impl<KC, DC> Database<KC, DC> {
         &self,
         txn: &'txn RwTxn<T>,
         prefix: &'a KC::EItem,
-    ) -> Result<RwRange<'txn, KC, DC>>
+    ) -> Result<RwPrefix<'txn, KC, DC>>
     where
         KC: BytesEncode<'a>,
     {

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -23,7 +23,7 @@ use crate::mdb::ffi;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
-/// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+/// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
@@ -70,7 +70,7 @@ use crate::mdb::ffi;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
 /// # let env = EnvOpenOptions::new()
-/// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+/// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
@@ -164,7 +164,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// let db: Database<Str, OwnedType<i32>> = env.create_database(Some("get-i32"))?;
@@ -208,7 +208,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -251,7 +251,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -290,7 +290,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -332,7 +332,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -374,7 +374,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -414,7 +414,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -469,7 +469,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -521,7 +521,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -586,7 +586,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -638,7 +638,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -700,7 +700,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -744,7 +744,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -787,7 +787,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -840,7 +840,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -894,7 +894,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -941,7 +941,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
@@ -990,7 +990,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
     /// # let env = EnvOpenOptions::new()
-    /// #     .map_size(10 * 1024 * 1024 * 1024) // 10GB
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -60,7 +60,7 @@ pub use heed_types as types;
 pub use zerocopy;
 use heed_traits as traits;
 
-pub use self::db::{Database, PolyDatabase, RoIter, RoRange, RwIter, RwRange};
+pub use self::db::{Database, PolyDatabase, RoIter, RoRange, RoPrefix, RwIter, RwRange, RwPrefix};
 pub use self::env::{CompactionOption, Env, EnvOpenOptions};
 pub use self::mdb::error::Error as MdbError;
 pub use self::mdb::flags;


### PR DESCRIPTION
Instead of using the `Ro/RwRange` iterator I introduce a real prefix iterator that works correctly in some specific cases where the bytes is `0xFF` and the end range key wasn't correctly generated (because it uses the `advance_key` function) giving errors in some specific cases.