### PR TITLE
Close environment safely

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -19,6 +19,7 @@ lmdb-rkv-sys = { version = "0.11.0", optional = true }
 mdbx-sys = { version = "0.7.1", optional = true }
 once_cell = "1.4.0"
 page_size = "0.4.2"
+synchronoise = "1.0.0"
 zerocopy = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -889,7 +889,7 @@ impl PolyDatabase {
     /// ```
     pub fn prefix_iter_mut<'a, 'txn, T, KC, DC>(
         &self,
-        txn: &'txn RwTxn<T>,
+        txn: &'txn mut RwTxn<T>,
         prefix: &'a KC::EItem,
     ) -> Result<RwPrefix<'txn, KC, DC>>
     where

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -104,12 +104,13 @@ use crate::types::DecodeIgnore;
 /// ```
 #[derive(Copy, Clone)]
 pub struct PolyDatabase {
+    pub(crate) env_ident: usize,
     pub(crate) dbi: ffi::MDB_dbi,
 }
 
 impl PolyDatabase {
-    pub(crate) fn new(dbi: ffi::MDB_dbi) -> PolyDatabase {
-        PolyDatabase { dbi }
+    pub(crate) fn new(env_ident: usize, dbi: ffi::MDB_dbi) -> PolyDatabase {
+        PolyDatabase { env_ident, dbi }
     }
 
     /// Retrieve the sequence of a database.
@@ -153,6 +154,8 @@ impl PolyDatabase {
     /// ```
     #[cfg(all(feature = "mdbx", not(feature = "lmdb")))]
     pub fn sequence<T>(&self, txn: &RoTxn<T>) -> Result<u64> {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let mut value = mem::MaybeUninit::uninit();
 
         let result = unsafe {
@@ -209,6 +212,8 @@ impl PolyDatabase {
     /// ```
     #[cfg(all(feature = "mdbx", not(feature = "lmdb")))]
     pub fn increase_sequence<T>(&self, txn: &mut RwTxn<T>, increment: u64) -> Result<Option<u64>> {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         use crate::mdb::error::Error;
 
         let mut value = mem::MaybeUninit::uninit();
@@ -271,6 +276,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a>,
         DC: BytesDecode<'txn>,
     {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
 
         let mut key_val = unsafe { crate::into_val(&key_bytes) };
@@ -336,6 +343,8 @@ impl PolyDatabase {
         KC: BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let mut cursor = RoCursor::new(txn, self.dbi)?;
         match cursor.move_on_first() {
             Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
@@ -387,6 +396,8 @@ impl PolyDatabase {
         KC: BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let mut cursor = RoCursor::new(txn, self.dbi)?;
         match cursor.move_on_last() {
             Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
@@ -437,6 +448,8 @@ impl PolyDatabase {
     /// # Ok(()) }
     /// ```
     pub fn len<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<usize> {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let mut cursor = RoCursor::new(txn, self.dbi)?;
         let mut count = 0;
 
@@ -491,6 +504,8 @@ impl PolyDatabase {
     /// # Ok(()) }
     /// ```
     pub fn is_empty<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<bool> {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let mut cursor = RoCursor::new(txn, self.dbi)?;
         match cursor.move_on_first()? {
             Some(_) => Ok(false),
@@ -535,6 +550,8 @@ impl PolyDatabase {
     /// # Ok(()) }
     /// ```
     pub fn iter<'txn, T, KC, DC>(&self, txn: &'txn RoTxn<T>) -> Result<RoIter<'txn, KC, DC>> {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         Ok(RoIter {
             cursor: RoCursor::new(txn, self.dbi)?,
             move_on_first: true,
@@ -592,6 +609,8 @@ impl PolyDatabase {
     /// # Ok(()) }
     /// ```
     pub fn iter_mut<'txn, T, KC, DC>(&self, txn: &'txn mut RwTxn<T>) -> Result<RwIter<'txn, KC, DC>> {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         Ok(RwIter {
             cursor: RwCursor::new(txn, self.dbi)?,
             move_on_first: true,
@@ -647,6 +666,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
     {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let start_bound = match range.start_bound() {
             Bound::Included(bound) => {
                 let bytes = KC::bytes_encode(bound).ok_or(Error::Encoding)?;
@@ -741,6 +762,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
     {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         let start_bound = match range.start_bound() {
             Bound::Included(bound) => {
                 let bytes = KC::bytes_encode(bound).ok_or(Error::Encoding)?;
@@ -822,6 +845,8 @@ impl PolyDatabase {
     where
         KC: BytesEncode<'a>,
     {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
         let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
 
@@ -895,6 +920,8 @@ impl PolyDatabase {
     where
         KC: BytesEncode<'a>,
     {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
 
@@ -949,6 +976,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a>,
         DC: BytesEncode<'a>,
     {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
 
@@ -1015,6 +1044,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a>,
         DC: BytesEncode<'a>,
     {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
 
@@ -1080,6 +1111,8 @@ impl PolyDatabase {
     where
         KC: BytesEncode<'a>,
     {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let mut key_val = unsafe { crate::into_val(&key_bytes) };
 
@@ -1152,6 +1185,8 @@ impl PolyDatabase {
         KC: BytesEncode<'a> + BytesDecode<'txn>,
         R: RangeBounds<KC::EItem>,
     {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         let mut count = 0;
         let mut iter = self.range_mut::<T, KC, DecodeIgnore, _>(txn, range)?;
 
@@ -1204,6 +1239,8 @@ impl PolyDatabase {
     /// # Ok(()) }
     /// ```
     pub fn clear<T>(&self, txn: &mut RwTxn<T>) -> Result<()> {
+        assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
+
         unsafe { mdb_result(ffi::mdb_drop(txn.txn.txn, self.dbi, 0)).map_err(Into::into) }
     }
 
@@ -1248,6 +1285,6 @@ impl PolyDatabase {
     /// # Ok(()) }
     /// ```
     pub fn as_uniform<KC, DC>(&self) -> Database<KC, DC> {
-        Database::new(self.dbi)
+        Database::new(self.env_ident, self.dbi)
     }
 }

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -120,9 +120,9 @@ pub struct Database<KC, DC> {
 }
 
 impl<KC, DC> Database<KC, DC> {
-    pub(crate) fn new(dbi: ffi::MDB_dbi) -> Database<KC, DC> {
+    pub(crate) fn new(env_ident: usize, dbi: ffi::MDB_dbi) -> Database<KC, DC> {
         Database {
-            dyndb: PolyDatabase::new(dbi),
+            dyndb: PolyDatabase::new(env_ident, dbi),
             marker: std::marker::PhantomData,
         }
     }
@@ -961,7 +961,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # Ok(()) }
     /// ```
     pub fn remap_types<KC2, DC2>(&self) -> Database<KC2, DC2> {
-        Database::new(self.dyndb.dbi)
+        Database::new(self.dyndb.env_ident, self.dyndb.dbi)
     }
 
     /// Get an handle on the internal polymorphic database.

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -678,7 +678,7 @@ impl<KC, DC> Database<KC, DC> {
     /// ```
     pub fn prefix_iter_mut<'a, 'txn, T>(
         &self,
-        txn: &'txn RwTxn<T>,
+        txn: &'txn mut RwTxn<T>,
         prefix: &'a KC::EItem,
     ) -> Result<RwPrefix<'txn, KC, DC>>
     where

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -456,7 +456,7 @@ impl Env {
     ///
     /// Make sure that you drop all the copies of `Env`s you have, env closing are triggered
     /// when all references are dropped, the last one will eventually close the environment.
-    pub fn close(self) -> EnvClosingEvent {
+    pub fn prepare_for_closing(self) -> EnvClosingEvent {
         let mut lock = OPENED_ENV.write().unwrap();
         let env = lock.get_mut(&self.0.path);
 
@@ -534,7 +534,7 @@ mod tests {
 
         wtxn.commit().unwrap();
 
-        let signal_event = env.close();
+        let signal_event = env.prepare_for_closing();
 
         eprintln!("waiting for the env to be closed");
         signal_event.wait();

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -482,15 +482,21 @@ impl Env {
 pub struct EnvClosingEvent(Arc<SignalEvent>);
 
 impl EnvClosingEvent {
-    /// Blocks this thread until another thread close the environment.
+    /// Blocks this thread until the environment is effectively closed.
+    ///
+    /// # Safety
+    ///
+    /// Make sure that you don't have any copy of the environment in the thread
+    /// that is waiting for a close event, if you do, you will have a dead-lock.
     pub fn wait(&self) {
         self.0.wait()
     }
 
-    /// Blocks this thread until either another thread close the environment,
-    /// or until the timeout elapses.
-    pub fn wait_timeout(&self, timeout: Duration) {
-        self.0.wait_timeout(timeout);
+    /// Blocks this thread until either the environment has been closed
+    /// or until the timeout elapses, returns `true` if the environment
+    /// has been effectively closed.
+    pub fn wait_timeout(&self, timeout: Duration) -> bool {
+        self.0.wait_timeout(timeout)
     }
 }
 

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -217,6 +217,10 @@ pub enum CompactionOption {
 }
 
 impl Env {
+    pub(crate) fn env_mut_ptr(&self) -> *mut ffi::MDB_env {
+        self.0.env
+    }
+
     pub fn open_database<KC, DC>(&self, name: Option<&str>) -> Result<Option<Database<KC, DC>>>
     where
         KC: 'static,
@@ -355,23 +359,23 @@ impl Env {
     }
 
     pub fn write_txn(&self) -> Result<RwTxn> {
-        RwTxn::new(self.0.env)
+        RwTxn::new(self)
     }
 
     pub fn typed_write_txn<T>(&self) -> Result<RwTxn<T>> {
-        RwTxn::<T>::new(self.0.env)
+        RwTxn::<T>::new(self)
     }
 
-    pub fn nested_write_txn<'p, T>(&self, parent: &'p mut RwTxn<T>) -> Result<RwTxn<'p, T>> {
-        RwTxn::nested(self.0.env, parent)
+    pub fn nested_write_txn<'e, 'p: 'e, T>(&'e self, parent: &'p mut RwTxn<T>) -> Result<RwTxn<'e, 'p, T>> {
+        RwTxn::nested(self, parent)
     }
 
     pub fn read_txn(&self) -> Result<RoTxn> {
-        RoTxn::new(self.0.env)
+        RoTxn::new(self)
     }
 
     pub fn typed_read_txn<T>(&self) -> Result<RoTxn<T>> {
-        RoTxn::new(self.0.env)
+        RoTxn::new(self)
     }
 
     // TODO rename into `copy_to_file` for more clarity

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -254,11 +254,12 @@ impl Env {
         let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
         Ok(self
             .raw_open_database(name, Some(types))?
-            .map(Database::new))
+            .map(|db| Database::new(self.env_mut_ptr() as _, db)))
     }
 
     pub fn open_poly_database(&self, name: Option<&str>) -> Result<Option<PolyDatabase>> {
-        Ok(self.raw_open_database(name, None)?.map(PolyDatabase::new))
+        Ok(self.raw_open_database(name, None)?
+                .map(|db| PolyDatabase::new(self.env_mut_ptr() as _, db)))
     }
 
     fn raw_open_database(
@@ -320,7 +321,7 @@ impl Env {
     {
         let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
         self.raw_create_database(name, Some(types), parent_wtxn)
-            .map(Database::new)
+            .map(|db| Database::new(self.env_mut_ptr() as _, db))
     }
 
     pub fn create_poly_database(&self, name: Option<&str>) -> Result<PolyDatabase> {
@@ -336,7 +337,7 @@ impl Env {
         parent_wtxn: &mut RwTxn,
     ) -> Result<PolyDatabase> {
         self.raw_create_database(name, None, parent_wtxn)
-            .map(PolyDatabase::new)
+            .map(|db| PolyDatabase::new(self.env_mut_ptr() as _, db))
     }
 
     fn raw_create_database(

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -428,6 +428,11 @@ impl Env {
         Ok(())
     }
 
+    /// Returns the canonicalized path where this env lives.
+    pub fn path(&self) -> &Path {
+        &self.0.path
+    }
+
     /// Returns wether this call initiate the close of this environment or not.
     ///
     /// Make sure that you drop all the copy of the Env you have, the closing is triggered

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -79,6 +79,7 @@ pub enum Error {
     Encoding,
     Decoding,
     InvalidDatabaseTyping,
+    DatabaseClosing,
 }
 
 impl fmt::Display for Error {
@@ -86,11 +87,14 @@ impl fmt::Display for Error {
         match self {
             Error::Io(error) => write!(f, "{}", error),
             Error::Mdb(error) => write!(f, "{}", error),
-            Error::Encoding => write!(f, "error while encoding"),
-            Error::Decoding => write!(f, "error while decoding"),
+            Error::Encoding => f.write_str("error while encoding"),
+            Error::Decoding => f.write_str("error while decoding"),
             Error::InvalidDatabaseTyping => {
-                write!(f, "database was previously opened with different types")
-            }
+                f.write_str("database was previously opened with different types")
+            },
+            Error::DatabaseClosing => {
+                f.write_str("database is in a closing phase, you can't open it at the same time")
+            },
         }
     }
 }

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -61,7 +61,7 @@ pub use zerocopy;
 use heed_traits as traits;
 
 pub use self::db::{Database, PolyDatabase, RoIter, RoRange, RoPrefix, RwIter, RwRange, RwPrefix};
-pub use self::env::{CompactionOption, Env, EnvOpenOptions};
+pub use self::env::{CompactionOption, Env, EnvOpenOptions, env_closing_event, EnvClosingEvent};
 pub use self::mdb::error::Error as MdbError;
 pub use self::mdb::flags;
 pub use self::traits::{BytesDecode, BytesEncode};

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -8,7 +8,7 @@ use crate::{Env, Result};
 
 pub struct RoTxn<'e, T=()> {
     pub(crate) txn: *mut ffi::MDB_txn,
-    _env: &'e Env,
+    pub(crate) env: &'e Env,
     _phantom: marker::PhantomData<T>,
 }
 
@@ -25,7 +25,7 @@ impl<'e, T> RoTxn<'e, T> {
             ))?
         };
 
-        Ok(RoTxn { txn, _env: env, _phantom: marker::PhantomData })
+        Ok(RoTxn { txn, env, _phantom: marker::PhantomData })
     }
 
     pub fn commit(mut self) -> Result<()> {
@@ -84,7 +84,7 @@ impl<'e, T> RwTxn<'e, 'e, T> {
         };
 
         Ok(RwTxn {
-            txn: RoTxn { txn, _env: env, _phantom: marker::PhantomData },
+            txn: RoTxn { txn, env, _phantom: marker::PhantomData },
             _parent: marker::PhantomData,
         })
     }
@@ -103,7 +103,7 @@ impl<'e, T> RwTxn<'e, 'e, T> {
         };
 
         Ok(RwTxn {
-            txn: RoTxn { txn, _env: env, _phantom: marker::PhantomData },
+            txn: RoTxn { txn, env, _phantom: marker::PhantomData },
             _parent: marker::PhantomData,
         })
     }

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -4,27 +4,28 @@ use std::ptr;
 
 use crate::mdb::ffi;
 use crate::mdb::error::mdb_result;
-use crate::Result;
+use crate::{Env, Result};
 
-pub struct RoTxn<T=()> {
+pub struct RoTxn<'e, T=()> {
     pub(crate) txn: *mut ffi::MDB_txn,
+    _env: &'e Env,
     _phantom: marker::PhantomData<T>,
 }
 
-impl<T> RoTxn<T> {
-    pub(crate) fn new(env: *mut ffi::MDB_env) -> Result<RoTxn<T>> {
+impl<'e, T> RoTxn<'e, T> {
+    pub(crate) fn new(env: &'e Env) -> Result<RoTxn<'e, T>> {
         let mut txn: *mut ffi::MDB_txn = ptr::null_mut();
 
         unsafe {
             mdb_result(ffi::mdb_txn_begin(
-                env,
+                env.env_mut_ptr(),
                 ptr::null_mut(),
                 ffi::MDB_RDONLY,
                 &mut txn,
             ))?
         };
 
-        Ok(RoTxn { txn, _phantom: marker::PhantomData })
+        Ok(RoTxn { txn, _env: env, _phantom: marker::PhantomData })
     }
 
     pub fn commit(mut self) -> Result<()> {
@@ -40,7 +41,7 @@ impl<T> RoTxn<T> {
     }
 }
 
-impl<T> Drop for RoTxn<T> {
+impl<T> Drop for RoTxn<'_, T> {
     fn drop(&mut self) {
         if !self.txn.is_null() {
             let _ = abort_txn(self.txn);
@@ -64,31 +65,45 @@ fn abort_txn(txn: *mut ffi::MDB_txn) -> Result<()> {
     mdb_result(ret).map_err(Into::into)
 }
 
-pub struct RwTxn<'p, T=()> {
-    pub(crate) txn: RoTxn<T>,
+pub struct RwTxn<'e, 'p, T=()> {
+    pub(crate) txn: RoTxn<'e, T>,
     _parent: marker::PhantomData<&'p mut ()>,
 }
 
-impl<T> RwTxn<'_, T> {
-    pub(crate) fn new(env: *mut ffi::MDB_env) -> Result<RwTxn<'static, T>> {
+impl<'e, T> RwTxn<'e, 'e, T> {
+    pub(crate) fn new(env: &'e Env) -> Result<RwTxn<'e, 'e, T>> {
         let mut txn: *mut ffi::MDB_txn = ptr::null_mut();
 
-        unsafe { mdb_result(ffi::mdb_txn_begin(env, ptr::null_mut(), 0, &mut txn))? };
+        unsafe {
+            mdb_result(ffi::mdb_txn_begin(
+                env.env_mut_ptr(),
+                ptr::null_mut(),
+                0,
+                &mut txn,
+            ))?
+        };
 
         Ok(RwTxn {
-            txn: RoTxn { txn, _phantom: marker::PhantomData },
+            txn: RoTxn { txn, _env: env, _phantom: marker::PhantomData },
             _parent: marker::PhantomData,
         })
     }
 
-    pub(crate) fn nested<'p>(env: *mut ffi::MDB_env, parent: &'p mut RwTxn<T>) -> Result<RwTxn<'p, T>> {
+    pub(crate) fn nested<'p: 'e>(env: &'e Env, parent: &'p mut RwTxn<T>) -> Result<RwTxn<'e, 'p, T>> {
         let mut txn: *mut ffi::MDB_txn = ptr::null_mut();
         let parent_ptr: *mut ffi::MDB_txn = parent.txn.txn;
 
-        unsafe { mdb_result(ffi::mdb_txn_begin(env, parent_ptr, 0, &mut txn))? };
+        unsafe {
+            mdb_result(ffi::mdb_txn_begin(
+                env.env_mut_ptr(),
+                parent_ptr,
+                0,
+                &mut txn,
+            ))?
+        };
 
         Ok(RwTxn {
-            txn: RoTxn { txn, _phantom: marker::PhantomData },
+            txn: RoTxn { txn, _env: env, _phantom: marker::PhantomData },
             _parent: marker::PhantomData,
         })
     }
@@ -102,8 +117,8 @@ impl<T> RwTxn<'_, T> {
     }
 }
 
-impl<T> Deref for RwTxn<'_, T> {
-    type Target = RoTxn<T>;
+impl<'e, 'p, T> Deref for RwTxn<'e, 'p, T> {
+    type Target = RoTxn<'e, T>;
 
     fn deref(&self) -> &Self::Target {
         &self.txn


### PR DESCRIPTION
The current heed version don't expose any way to close an environment because many requierements are needed by either lmdb or mdbx to safely do that. Once closed, no active transaction must be used on any database, in short: all databases and transactions must be closed or aborted, if this is not the case, a `SIGSEGV` will be thrown.

I found a pretty way to expose a close api to the environment, [I added a lifetime to the transactions, the lifetime of the environment they were made from](https://github.com/Kerollmops/heed/pull/64/files?file-filters%5B%5D=.rs#diff-c40afad6bbd223832a2f86c38702313beb78366bd30bbfcd6d014e8cc651dafeR9-R13), this indicates that no transaction can live longer than the environment and therefore when an environment is dropped, [the last reference (because it is `Arc`ed) is dropped, the environment can be safely closed](https://github.com/Kerollmops/heed/pull/64/files?file-filters%5B%5D=.rs#diff-ac577a0bca84e6fbce36b3a413107331b37c74809219009e740896600a1d97f7R229-R242).

The close api is a `prepare_for_closing` self consuming method on the `Env` struct which returns a `EnvClosingEvent` that allows the user to wait for the environment to effectively close.

```rust
let env = EnvOpenOptions::new().open("my-env.mdb")?;
let closing_event = env.prepare_for_closing();
closing_event.wait(); // once it unblocks the thread, the env has been closed.

// another thread can also use the env_closing_event function
if let Some(closing_event) = env_closing_event("my-env.mdb") {
    closing_event.wait();
}
```

I also added a new safety guard to the transactions and databases to make sure that a transaction is always used on a database which comes from the same environment, I store the environment pointer (as an `usize`) in the `Database` this way [we are able to assert that the transaction environment pointer (which is referenced in the transaction) is equal to the one in the Database](https://github.com/Kerollmops/heed/pull/64/files#diff-be1d9b2d86fd3893a95f16a687e9e2c5d7e0c609f1840319437f9baeebd736f0R450-R454).