### PR TITLE
Introduce the get_lower/greater_than methods

### DIFF
--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -402,19 +402,19 @@ impl PolyDatabase {
     /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(42), &())?;
     /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(43), &())?;
     ///
-    /// let ret = db.get_gt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(0))?;
+    /// let ret = db.get_greater_than::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(0))?;
     /// assert_eq!(ret, Some((BEU32::new(27), ())));
     ///
-    /// let ret = db.get_gt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(42))?;
+    /// let ret = db.get_greater_than::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(42))?;
     /// assert_eq!(ret, Some((BEU32::new(43), ())));
     ///
-    /// let ret = db.get_gt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(43))?;
+    /// let ret = db.get_greater_than::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(43))?;
     /// assert_eq!(ret, None);
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_gt<'a, 'txn, T, KC, DC>(
+    pub fn get_greater_than<'a, 'txn, T, KC, DC>(
         &self,
         txn: &'txn RoTxn<T>,
         key: &'a KC::EItem,

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -334,19 +334,19 @@ impl PolyDatabase {
     /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(42), &())?;
     /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(43), &())?;
     ///
-    /// let ret = db.get_lt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(4404))?;
+    /// let ret = db.get_lower_than::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(4404))?;
     /// assert_eq!(ret, Some((BEU32::new(43), ())));
     ///
-    /// let ret = db.get_lt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(43))?;
+    /// let ret = db.get_lower_than::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(43))?;
     /// assert_eq!(ret, Some((BEU32::new(42), ())));
     ///
-    /// let ret = db.get_lt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(27))?;
+    /// let ret = db.get_lower_than::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(27))?;
     /// assert_eq!(ret, None);
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lt<'a, 'txn, T, KC, DC>(
+    pub fn get_lower_than<'a, 'txn, T, KC, DC>(
         &self,
         txn: &'txn RoTxn<T>,
         key: &'a KC::EItem,

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -371,6 +371,77 @@ impl PolyDatabase {
         }
     }
 
+    /// Retrieves the key/value pair greater than the given one in this database.
+    ///
+    /// If the database if empty or there is no key greater than the given one,
+    /// then `None` is returned.
+    ///
+    /// Comparisons are made by using the bytes representation of the key.
+    ///
+    /// ```
+    /// # use std::fs;
+    /// # use std::path::Path;
+    /// # use heed::EnvOpenOptions;
+    /// use heed::Database;
+    /// use heed::types::*;
+    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # let env = EnvOpenOptions::new()
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
+    /// #     .max_dbs(3000)
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// type BEU32 = U32<BigEndian>;
+    ///
+    /// let db = env.create_poly_database(Some("get-lt-u32"))?;
+    ///
+    /// let mut wtxn = env.write_txn()?;
+    /// # db.clear(&mut wtxn)?;
+    /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(27), &())?;
+    /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(42), &())?;
+    /// db.put::<_, OwnedType<BEU32>, Unit>(&mut wtxn, &BEU32::new(43), &())?;
+    ///
+    /// let ret = db.get_gt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(0))?;
+    /// assert_eq!(ret, Some((BEU32::new(27), ())));
+    ///
+    /// let ret = db.get_gt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(42))?;
+    /// assert_eq!(ret, Some((BEU32::new(43), ())));
+    ///
+    /// let ret = db.get_gt::<_, OwnedType<BEU32>, Unit>(&wtxn, &BEU32::new(43))?;
+    /// assert_eq!(ret, None);
+    ///
+    /// wtxn.commit()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_gt<'a, 'txn, T, KC, DC>(
+        &self,
+        txn: &'txn RoTxn<T>,
+        key: &'a KC::EItem,
+    ) -> Result<Option<(KC::DItem, DC::DItem)>>
+    where
+        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        DC: BytesDecode<'txn>,
+    {
+        assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
+
+        let mut cursor = RoCursor::new(txn, self.dbi)?;
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
+        let entry = match cursor.move_on_key_greater_than_or_equal_to(&key_bytes)? {
+            Some((key, data)) if key > &key_bytes[..] => Some((key, data)),
+            Some((_key, _data)) => cursor.move_on_next()?,
+            None => None,
+        };
+
+        match entry {
+            Some((key, data)) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
+                (Some(key), Some(data)) => Ok(Some((key, data))),
+                (_, _) => Err(Error::Decoding),
+            },
+            None => Ok(None),
+        }
+    }
+
     /// Retrieves the first key/value pair of this database.
     ///
     /// If the database if empty, then `None` is returned.

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -246,6 +246,61 @@ impl<KC, DC> Database<KC, DC> {
         self.dyndb.get_lt::<T, KC, DC>(txn, key)
     }
 
+    /// Retrieves the key/value pair greater than the given one in this database.
+    ///
+    /// If the database if empty or there is no key greater than the given one,
+    /// then `None` is returned.
+    ///
+    /// Comparisons are made by using the bytes representation of the key.
+    ///
+    /// ```
+    /// # use std::fs;
+    /// # use std::path::Path;
+    /// # use heed::EnvOpenOptions;
+    /// use heed::Database;
+    /// use heed::types::*;
+    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # let env = EnvOpenOptions::new()
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
+    /// #     .max_dbs(3000)
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// type BEU32 = U32<BigEndian>;
+    ///
+    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
+    ///
+    /// let mut wtxn = env.write_txn()?;
+    /// # db.clear(&mut wtxn)?;
+    /// db.put(&mut wtxn, &BEU32::new(27), &())?;
+    /// db.put(&mut wtxn, &BEU32::new(42), &())?;
+    /// db.put(&mut wtxn, &BEU32::new(43), &())?;
+    ///
+    /// let ret = db.get_gt(&wtxn, &BEU32::new(0))?;
+    /// assert_eq!(ret, Some((BEU32::new(27), ())));
+    ///
+    /// let ret = db.get_gt(&wtxn, &BEU32::new(42))?;
+    /// assert_eq!(ret, Some((BEU32::new(43), ())));
+    ///
+    /// let ret = db.get_gt(&wtxn, &BEU32::new(43))?;
+    /// assert_eq!(ret, None);
+    ///
+    /// wtxn.commit()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_gt<'a, 'txn, T>(
+        &self,
+        txn: &'txn RoTxn<T>,
+        key: &'a KC::EItem,
+    ) -> Result<Option<(KC::DItem, DC::DItem)>>
+    where
+        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        DC: BytesDecode<'txn>,
+    {
+        self.dyndb.get_gt::<T, KC, DC>(txn, key)
+    }
+
     /// Retrieves the first key/value pair of this database.
     ///
     /// If the database if empty, then `None` is returned.

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -277,19 +277,19 @@ impl<KC, DC> Database<KC, DC> {
     /// db.put(&mut wtxn, &BEU32::new(42), &())?;
     /// db.put(&mut wtxn, &BEU32::new(43), &())?;
     ///
-    /// let ret = db.get_gt(&wtxn, &BEU32::new(0))?;
+    /// let ret = db.get_greater_than(&wtxn, &BEU32::new(0))?;
     /// assert_eq!(ret, Some((BEU32::new(27), ())));
     ///
-    /// let ret = db.get_gt(&wtxn, &BEU32::new(42))?;
+    /// let ret = db.get_greater_than(&wtxn, &BEU32::new(42))?;
     /// assert_eq!(ret, Some((BEU32::new(43), ())));
     ///
-    /// let ret = db.get_gt(&wtxn, &BEU32::new(43))?;
+    /// let ret = db.get_greater_than(&wtxn, &BEU32::new(43))?;
     /// assert_eq!(ret, None);
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_gt<'a, 'txn, T>(
+    pub fn get_greater_than<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
         key: &'a KC::EItem,
@@ -298,7 +298,7 @@ impl<KC, DC> Database<KC, DC> {
         KC: BytesEncode<'a> + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
-        self.dyndb.get_gt::<T, KC, DC>(txn, key)
+        self.dyndb.get_greater_than::<T, KC, DC>(txn, key)
     }
 
     /// Retrieves the first key/value pair of this database.

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -222,19 +222,19 @@ impl<KC, DC> Database<KC, DC> {
     /// db.put(&mut wtxn, &BEU32::new(42), &())?;
     /// db.put(&mut wtxn, &BEU32::new(43), &())?;
     ///
-    /// let ret = db.get_lt(&wtxn, &BEU32::new(4404))?;
+    /// let ret = db.get_lower_than(&wtxn, &BEU32::new(4404))?;
     /// assert_eq!(ret, Some((BEU32::new(43), ())));
     ///
-    /// let ret = db.get_lt(&wtxn, &BEU32::new(43))?;
+    /// let ret = db.get_lower_than(&wtxn, &BEU32::new(43))?;
     /// assert_eq!(ret, Some((BEU32::new(42), ())));
     ///
-    /// let ret = db.get_lt(&wtxn, &BEU32::new(27))?;
+    /// let ret = db.get_lower_than(&wtxn, &BEU32::new(27))?;
     /// assert_eq!(ret, None);
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lt<'a, 'txn, T>(
+    pub fn get_lower_than<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
         key: &'a KC::EItem,
@@ -243,7 +243,7 @@ impl<KC, DC> Database<KC, DC> {
         KC: BytesEncode<'a> + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
-        self.dyndb.get_lt::<T, KC, DC>(txn, key)
+        self.dyndb.get_lower_than::<T, KC, DC>(txn, key)
     }
 
     /// Retrieves the key/value pair greater than the given one in this database.

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -191,6 +191,61 @@ impl<KC, DC> Database<KC, DC> {
         self.dyndb.get::<T, KC, DC>(txn, key)
     }
 
+    /// Retrieves the key/value pair lower than the given one in this database.
+    ///
+    /// If the database if empty or there is no key lower than the given one,
+    /// then `None` is returned.
+    ///
+    /// Comparisons are made by using the bytes representation of the key.
+    ///
+    /// ```
+    /// # use std::fs;
+    /// # use std::path::Path;
+    /// # use heed::EnvOpenOptions;
+    /// use heed::Database;
+    /// use heed::types::*;
+    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # let env = EnvOpenOptions::new()
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
+    /// #     .max_dbs(3000)
+    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// type BEU32 = U32<BigEndian>;
+    ///
+    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
+    ///
+    /// let mut wtxn = env.write_txn()?;
+    /// # db.clear(&mut wtxn)?;
+    /// db.put(&mut wtxn, &BEU32::new(27), &())?;
+    /// db.put(&mut wtxn, &BEU32::new(42), &())?;
+    /// db.put(&mut wtxn, &BEU32::new(43), &())?;
+    ///
+    /// let ret = db.get_lt(&wtxn, &BEU32::new(4404))?;
+    /// assert_eq!(ret, Some((BEU32::new(43), ())));
+    ///
+    /// let ret = db.get_lt(&wtxn, &BEU32::new(43))?;
+    /// assert_eq!(ret, Some((BEU32::new(42), ())));
+    ///
+    /// let ret = db.get_lt(&wtxn, &BEU32::new(27))?;
+    /// assert_eq!(ret, None);
+    ///
+    /// wtxn.commit()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_lt<'a, 'txn, T>(
+        &self,
+        txn: &'txn RoTxn<T>,
+        key: &'a KC::EItem,
+    ) -> Result<Option<(KC::DItem, DC::DItem)>>
+    where
+        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        DC: BytesDecode<'txn>,
+    {
+        self.dyndb.get_lt::<T, KC, DC>(txn, key)
+    }
+
     /// Retrieves the first key/value pair of this database.
     ///
     /// If the database if empty, then `None` is returned.

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -43,6 +43,7 @@ pub mod cursor_op {
     pub const MDB_FIRST: MDB_cursor_op = ffi::MDB_FIRST;
     pub const MDB_LAST: MDB_cursor_op = ffi::MDB_LAST;
     pub const MDB_SET_RANGE: MDB_cursor_op = ffi::MDB_SET_RANGE;
+    pub const MDB_PREV: MDB_cursor_op = ffi::MDB_PREV;
     pub const MDB_NEXT: MDB_cursor_op = ffi::MDB_NEXT;
 }
 

--- a/heed/src/mdb/mdbx_ffi.rs
+++ b/heed/src/mdb/mdbx_ffi.rs
@@ -44,6 +44,7 @@ pub mod cursor_op {
     pub const MDB_FIRST: MDBX_cursor_op = MDBX_cursor_op::MDBX_FIRST;
     pub const MDB_LAST: MDBX_cursor_op = MDBX_cursor_op::MDBX_LAST;
     pub const MDB_SET_RANGE: MDBX_cursor_op = MDBX_cursor_op::MDBX_SET_RANGE;
+    pub const MDB_PREV: MDBX_cursor_op = MDBX_cursor_op::MDBX_PREV;
     pub const MDB_NEXT: MDBX_cursor_op = MDBX_cursor_op::MDBX_NEXT;
 }
 


### PR DESCRIPTION
Introduce new methods to retrieve a key just lower or greater than the given key in a database. It uses a cursor internally.