### PR TITLE
Efficient Iterator last method

### DIFF
--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -971,7 +971,8 @@ impl PolyDatabase {
 
         Ok(RoRange {
             cursor: RoCursor::new(txn, self.dbi)?,
-            start_bound: Some(start_bound),
+            move_on_start: true,
+            start_bound,
             end_bound,
             _phantom: marker::PhantomData,
         })
@@ -1067,7 +1068,8 @@ impl PolyDatabase {
 
         Ok(RwRange {
             cursor: RwCursor::new(txn, self.dbi)?,
-            start_bound: Some(start_bound),
+            move_on_start: true,
+            start_bound: start_bound,
             end_bound,
             _phantom: marker::PhantomData,
         })

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -45,6 +45,7 @@ pub mod cursor_op {
     pub const MDB_SET_RANGE: MDB_cursor_op = ffi::MDB_SET_RANGE;
     pub const MDB_PREV: MDB_cursor_op = ffi::MDB_PREV;
     pub const MDB_NEXT: MDB_cursor_op = ffi::MDB_NEXT;
+    pub const MDB_GET_CURRENT: MDB_cursor_op = ffi::MDB_GET_CURRENT;
 }
 
 pub unsafe fn into_val(value: &[u8]) -> ffi::MDB_val {

--- a/heed/src/mdb/mdbx_ffi.rs
+++ b/heed/src/mdb/mdbx_ffi.rs
@@ -46,6 +46,7 @@ pub mod cursor_op {
     pub const MDB_SET_RANGE: MDBX_cursor_op = MDBX_cursor_op::MDBX_SET_RANGE;
     pub const MDB_PREV: MDBX_cursor_op = MDBX_cursor_op::MDBX_PREV;
     pub const MDB_NEXT: MDBX_cursor_op = MDBX_cursor_op::MDBX_NEXT;
+    pub const MDB_GET_CURRENT: MDBX_cursor_op = MDBX_cursor_op::MDBX_GET_CURRENT;
 }
 
 pub unsafe fn into_val(value: &[u8]) -> ffi::MDBX_val {


### PR DESCRIPTION
Improve the `Iterator::last` method on `Ro/RwIter`  and `Ro/RwRange` iterator structs.