### PR TITLE
Implement Serde on EnvOpenOptions

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -19,17 +19,20 @@ lmdb-rkv-sys = { version = "0.11.0", optional = true }
 mdbx-sys = { version = "0.7.1", optional = true }
 once_cell = "1.5.2"
 page_size = "0.4.2"
+serde = { version = "1.0.118", features = ["derive"], optional = true }
 synchronoise = "1.0.0"
 zerocopy = "0.3.0"
+
+[dev-dependencies]
+serde = { version = "1.0.118", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 url = "2.2.0"
 
-[dev-dependencies]
-serde = { version = "1.0.117", features = ["derive"] }
-
 [features]
-default = ["lmdb", "serde-bincode", "serde-json"]
+# The `serde` feature makes some types serializable,
+# like the `EnvOpenOptions` struct.
+default = ["lmdb", "serde", "serde-bincode", "serde-json"]
 
 # The NO_TLS flag is automatically set on Env opening and
 # RoTxn implements the Sync trait. This allow the user to reference

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -66,6 +66,7 @@ fn get_file_fd(file: &File) -> std::os::unix::io::RawFd {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnvOpenOptions {
     map_size: Option<usize>,
     max_readers: Option<u32>,


### PR DESCRIPTION
This way it is possible to store the env opening settings and read them back.