### PR TITLE
Custom key comparison functions

### DIFF
--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -13,6 +13,18 @@ pub trait BytesDecode<'a> {
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem>;
 }
 
+/// Define a custom key comparison function for a database.
+///
+/// The comparison function is called whenever it is necessary to compare a key specified
+/// by the application with a key currently stored in the database. If no comparison function
+/// is specified, and no special key flags were specified, the keys are compared lexically,
+/// with shorter keys collating before longer keys.
 pub trait CustomKeyCmp {
+    /// Compares the raw bytes representation of two keys.
+    ///
+    /// # Safety
+    ///
+    /// This function must never crash, this is the reason why it takes raw bytes as parameter,
+    /// to let you define the recovery method you want in case of a decoding error.
     fn compare(a: &[u8], b: &[u8]) -> Ordering;
 }

--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -13,8 +13,6 @@ pub trait BytesDecode<'a> {
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem>;
 }
 
-pub trait CustomKeyCmp<'a> {
-    type Key: 'a;
-
-    fn compare(a: Self::Key, b: Self::Key) -> Ordering;
+pub trait CustomKeyCmp {
+    fn compare(a: &[u8], b: &[u8]) -> Ordering;
 }

--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -13,6 +13,8 @@ pub trait BytesDecode<'a> {
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem>;
 }
 
-pub trait CustomKeyCmp {
-    fn compare(a: &[u8], b: &[u8]) -> Ordering;
+pub trait CustomKeyCmp<'a> {
+    type Key: 'a;
+
+    fn compare(a: Self::Key, b: Self::Key) -> Ordering;
 }

--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cmp::Ordering;
 
 pub trait BytesEncode<'a> {
     type EItem: ?Sized + 'a;
@@ -10,4 +11,8 @@ pub trait BytesDecode<'a> {
     type DItem: 'a;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem>;
+}
+
+pub trait CustomKeyCmp {
+    fn compare(a: &[u8], b: &[u8]) -> Ordering;
 }

--- a/heed/examples/custom-key-cmp.rs
+++ b/heed/examples/custom-key-cmp.rs
@@ -21,6 +21,7 @@ impl CustomKeyCmp for StringAsIntCmp {
 
 // In this test we are checking that we can use
 // a custom key comparison function at database creation.
+#[cfg(all(feature = "lmdb", not(feature = "mdbx")))]
 fn main() -> Result<(), Box<dyn Error>> {
     let env_path = Path::new("target").join("custom-key-cmp.mdb");
 
@@ -52,5 +53,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     assert_eq!(iter.next().transpose()?, Some(("100", ())));
     drop(iter);
 
+    Ok(())
+}
+
+#[cfg(all(feature = "mdbx", not(feature = "lmdb")))]
+fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }

--- a/heed/examples/custom-key-cmp.rs
+++ b/heed/examples/custom-key-cmp.rs
@@ -1,0 +1,56 @@
+use std::error::Error;
+use std::{fs, str};
+use std::cmp::Ordering;
+use std::path::Path;
+
+use heed::types::*;
+use heed::{Database, EnvOpenOptions, CustomKeyCmp};
+
+enum StringAsIntCmp {}
+
+// This function takes two strings which represent positive numbers,
+// parses them into i32s and compare the parsed value.
+// Therefore "-1000" < "-100" must be true even without '0' padding.
+impl CustomKeyCmp for StringAsIntCmp {
+    fn compare(a: &[u8], b: &[u8]) -> Ordering {
+        let a: i32 = str::from_utf8(a).unwrap().parse().unwrap();
+        let b: i32 = str::from_utf8(b).unwrap().parse().unwrap();
+        a.cmp(&b)
+    }
+}
+
+// In this test we are checking that we can use
+// a custom key comparison function at database creation.
+fn main() -> Result<(), Box<dyn Error>> {
+    let env_path = Path::new("target").join("custom-key-cmp.mdb");
+
+    let _ = fs::remove_dir_all(&env_path);
+
+    fs::create_dir_all(&env_path)?;
+    let env = EnvOpenOptions::new()
+        .map_size(10 * 1024 * 1024) // 10MB
+        .max_dbs(3)
+        .open(env_path)?;
+
+    let db: Database<Str, Unit> = env.create_database_with_custom_key_cmp::<_, _, StringAsIntCmp>(None)?;
+
+    let mut wtxn = env.write_txn()?;
+
+    // We fill our database with entries.
+    db.put(&mut wtxn, "-100000", &())?;
+    db.put(&mut wtxn, "-10000", &())?;
+    db.put(&mut wtxn, "-1000", &())?;
+    db.put(&mut wtxn, "-100", &())?;
+    db.put(&mut wtxn, "100", &())?;
+
+    // We check that the key are in the right order ("-100" < "-1000" < "-10000"...)
+    let mut iter = db.iter(&wtxn)?;
+    assert_eq!(iter.next().transpose()?, Some(("-100000", ())));
+    assert_eq!(iter.next().transpose()?, Some(("-10000", ())));
+    assert_eq!(iter.next().transpose()?, Some(("-1000", ())));
+    assert_eq!(iter.next().transpose()?, Some(("-100", ())));
+    assert_eq!(iter.next().transpose()?, Some(("100", ())));
+    drop(iter);
+
+    Ok(())
+}

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -300,6 +300,7 @@ impl Env {
             .map(|db| Database::new(self.env_mut_ptr() as _, db)))
     }
 
+    #[cfg(all(feature = "lmdb", not(feature = "mdbx")))]
     pub fn open_database_with_custom_key_cmp<KC, DC, C>(
         &self,
         name: Option<&str>,
@@ -385,6 +386,7 @@ impl Env {
         Ok(db)
     }
 
+    #[cfg(all(feature = "lmdb", not(feature = "mdbx")))]
     pub fn create_database_with_custom_key_cmp<KC, DC, C>(
         &self,
         name: Option<&str>,
@@ -414,6 +416,7 @@ impl Env {
             .map(|db| Database::new(self.env_mut_ptr() as _, db))
     }
 
+    #[cfg(all(feature = "lmdb", not(feature = "mdbx")))]
     pub fn create_database_with_txn_and_custom_key_cmp<KC, DC, C>(
         &self,
         name: Option<&str>,

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -19,6 +19,7 @@ use crate::flags::Flags;
 use crate::mdb::error::mdb_result;
 use crate::{Database, CustomKeyCmp, Error, Result, RoTxn, RwTxn};
 use crate::mdb::ffi;
+use crate::BytesDecode;
 
 /// The list of opened environments, the value is an optional environment, it is None
 /// when someone asks to close the environment, closing is a two-phase step, to make sure
@@ -262,13 +263,20 @@ pub enum CompactionOption {
 
 /// An helping function that transforms the LMDB types into Rust types (`MDB_val` into slices)
 /// and vice versa, the Rust types into C types (`Ordering` into an integer).
-extern "C" fn custom_key_cmp_wrapper<C: CustomKeyCmp>(
+extern "C" fn custom_key_cmp_wrapper<'a, KC, C, K>(
     a: *const ffi::MDB_val,
     b: *const ffi::MDB_val,
 ) -> i32
+where
+    KC: BytesDecode<'a, DItem = K>,
+    C: CustomKeyCmp<'a, Key = K>,
 {
     let a = unsafe { ffi::from_val(*a) };
     let b = unsafe { ffi::from_val(*b) };
+
+    let a = KC::bytes_decode(a).unwrap();
+    let b = KC::bytes_decode(b).unwrap();
+
     match C::compare(a, b) {
         Ordering::Less => -1,
         Ordering::Equal => 0,
@@ -276,11 +284,13 @@ extern "C" fn custom_key_cmp_wrapper<C: CustomKeyCmp>(
     }
 }
 
-enum DummyCustomKeyCmp {}
+struct DummyCustomKeyCmp<K>(std::marker::PhantomData<K>);
 
-impl CustomKeyCmp for DummyCustomKeyCmp {
-    fn compare(a: &[u8], b: &[u8]) -> Ordering {
-        a.cmp(b)
+impl<'a, K: 'a> CustomKeyCmp<'a> for DummyCustomKeyCmp<K> {
+    type Key = K;
+
+    fn compare(_a: Self::Key, _b: Self::Key) -> Ordering {
+        Ordering::Equal
     }
 }
 
@@ -291,39 +301,39 @@ impl Env {
 
     pub fn open_database<KC, DC>(&self, name: Option<&str>) -> Result<Option<Database<KC, DC>>>
     where
-        KC: 'static,
+        KC: 'static + for<'a> BytesDecode<'a>,
         DC: 'static,
     {
-        let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
         Ok(self
-            .raw_open_database::<DummyCustomKeyCmp>(name, types, false)?
+            .raw_open_database::<KC, DC, DummyCustomKeyCmp<KC::DItem>, _>(name, false)?
             .map(|db| Database::new(self.env_mut_ptr() as _, db)))
     }
 
-    pub fn open_database_with_custom_key_cmp<KC, DC, C>(
+    pub fn open_database_with_custom_key_cmp<'a, KC, DC, C, K>(
         &self,
         name: Option<&str>,
     ) -> Result<Option<Database<KC, DC>>>
     where
-        KC: 'static,
+        KC: 'static + BytesDecode<'a, DItem = K>,
         DC: 'static,
-        C: CustomKeyCmp,
+        C: CustomKeyCmp<'a, Key = K>,
     {
-        let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
         Ok(self
-            .raw_open_database::<C>(name, types, true)?
+            .raw_open_database::<KC, DC, C, _>(name, true)?
             .map(|db| Database::new(self.env_mut_ptr() as _, db)))
     }
 
-    fn raw_open_database<C>(
+    fn raw_open_database<'a, KC, DC, C, K>(
         &self,
         name: Option<&str>,
-        types: (TypeId, TypeId),
         use_custom_key_cmp: bool,
     ) -> Result<Option<u32>>
     where
-        C: CustomKeyCmp,
+        KC: 'static + BytesDecode<'a, DItem = K>,
+        DC: 'static,
+        C: CustomKeyCmp<'a, Key = K>,
     {
+        let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
         let rtxn = self.read_txn()?;
 
         let mut dbi = 0;
@@ -353,7 +363,7 @@ impl Env {
                         mdb_result(ffi::mdb_set_compare(
                             rtxn.txn,
                             dbi,
-                            Some(custom_key_cmp_wrapper::<C>),
+                            Some(custom_key_cmp_wrapper::<KC, C, K>),
                         ))?;
                     }
                 }
@@ -376,7 +386,7 @@ impl Env {
 
     pub fn create_database<KC, DC>(&self, name: Option<&str>) -> Result<Database<KC, DC>>
     where
-        KC: 'static,
+        KC: 'static + for<'a> BytesDecode<'a>,
         DC: 'static,
     {
         let mut parent_wtxn = self.write_txn()?;
@@ -385,17 +395,17 @@ impl Env {
         Ok(db)
     }
 
-    pub fn create_database_with_custom_key_cmp<KC, DC, C>(
+    pub fn create_database_with_custom_key_cmp<'a, KC, DC, C, K>(
         &self,
         name: Option<&str>,
     ) -> Result<Database<KC, DC>>
     where
-        KC: 'static,
+        KC: 'static + BytesDecode<'a, DItem = K>,
         DC: 'static,
-        C: CustomKeyCmp,
+        C: CustomKeyCmp<'a, Key = K>,
     {
         let mut parent_wtxn = self.write_txn()?;
-        let db = self.create_database_with_txn_and_custom_key_cmp::<_, _, C>(name, &mut parent_wtxn)?;
+        let db = self.create_database_with_txn_and_custom_key_cmp::<_, _, C, _>(name, &mut parent_wtxn)?;
         parent_wtxn.commit()?;
         Ok(db)
     }
@@ -406,39 +416,39 @@ impl Env {
         parent_wtxn: &mut RwTxn,
     ) -> Result<Database<KC, DC>>
     where
-        KC: 'static,
+        KC: 'static + for<'a> BytesDecode<'a>,
         DC: 'static,
     {
-        let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
-        self.raw_create_database::<DummyCustomKeyCmp>(name, types, parent_wtxn, false)
+        self.raw_create_database::<KC, DC, DummyCustomKeyCmp<KC::DItem>, _>(name, parent_wtxn, false)
             .map(|db| Database::new(self.env_mut_ptr() as _, db))
     }
 
-    pub fn create_database_with_txn_and_custom_key_cmp<KC, DC, C>(
+    pub fn create_database_with_txn_and_custom_key_cmp<'a, KC, DC, C, K>(
         &self,
         name: Option<&str>,
         parent_wtxn: &mut RwTxn,
     ) -> Result<Database<KC, DC>>
     where
-        KC: 'static,
+        KC: 'static + BytesDecode<'a, DItem = K>,
         DC: 'static,
-        C: CustomKeyCmp,
+        C: CustomKeyCmp<'a, Key = K>,
     {
-        let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
-        self.raw_create_database::<C>(name, types, parent_wtxn, true)
+        self.raw_create_database::<KC, DC, C, _>(name, parent_wtxn, true)
             .map(|db| Database::new(self.env_mut_ptr() as _, db))
     }
 
-    fn raw_create_database<C>(
+    fn raw_create_database<'a, KC, DC, C, K>(
         &self,
         name: Option<&str>,
-        types: (TypeId, TypeId),
         parent_wtxn: &mut RwTxn,
         use_custom_key_cmp: bool,
     ) -> Result<u32>
     where
-        C: CustomKeyCmp,
+        KC: 'static + BytesDecode<'a, DItem = K>,
+        DC: 'static,
+        C: CustomKeyCmp<'a, Key = K>,
     {
+        let types = (TypeId::of::<KC>(), TypeId::of::<DC>());
         let wtxn = self.nested_write_txn(parent_wtxn)?;
 
         let mut dbi = 0;
@@ -468,7 +478,7 @@ impl Env {
                         mdb_result(ffi::mdb_set_compare(
                             wtxn.txn.txn,
                             dbi,
-                            Some(custom_key_cmp_wrapper::<C>),
+                            Some(custom_key_cmp_wrapper::<KC, C, K>),
                         ))?;
                     }
                 }

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -17,7 +17,7 @@ use synchronoise::event::SignalEvent;
 
 use crate::flags::Flags;
 use crate::mdb::error::mdb_result;
-use crate::{Database, Error, Result, RoTxn, RwTxn};
+use crate::{Database, CustomKeyCmp, Error, Result, RoTxn, RwTxn};
 use crate::mdb::ffi;
 
 /// The list of opened environments, the value is an optional environment, it is None
@@ -260,6 +260,8 @@ pub enum CompactionOption {
     Disabled,
 }
 
+/// An helping function that transforms the LMDB types into Rust types (`MDB_val` into slices)
+/// and vice versa, the Rust types into C types (`Ordering` into an integer).
 extern "C" fn custom_key_cmp_wrapper<C: CustomKeyCmp>(
     a: *const ffi::MDB_val,
     b: *const ffi::MDB_val,
@@ -272,10 +274,6 @@ extern "C" fn custom_key_cmp_wrapper<C: CustomKeyCmp>(
         Ordering::Equal => 0,
         Ordering::Greater => 1,
     }
-}
-
-pub trait CustomKeyCmp {
-    fn compare(a: &[u8], b: &[u8]) -> Ordering;
 }
 
 enum DummyCustomKeyCmp {}

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -61,6 +61,7 @@ pub use zerocopy;
 use heed_traits as traits;
 
 pub use self::database::Database;
+pub use self::env::CustomKeyCmp;
 pub use self::env::{CompactionOption, Env, EnvOpenOptions, env_closing_event, EnvClosingEvent};
 pub use self::iter::{RoIter, RoRevIter, RwIter, RwRevIter};
 pub use self::iter::{RoPrefix, RoRevPrefix, RwPrefix, RwRevPrefix};

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -61,7 +61,6 @@ pub use zerocopy;
 use heed_traits as traits;
 
 pub use self::database::Database;
-pub use self::env::CustomKeyCmp;
 pub use self::env::{CompactionOption, Env, EnvOpenOptions, env_closing_event, EnvClosingEvent};
 pub use self::iter::{RoIter, RoRevIter, RwIter, RwRevIter};
 pub use self::iter::{RoPrefix, RoRevPrefix, RwPrefix, RwRevPrefix};
@@ -69,7 +68,7 @@ pub use self::iter::{RoRange, RoRevRange, RwRange, RwRevRange};
 pub use self::lazy_decode::{LazyDecode, Lazy};
 pub use self::mdb::error::Error as MdbError;
 pub use self::mdb::flags;
-pub use self::traits::{BytesDecode, BytesEncode};
+pub use self::traits::{BytesDecode, BytesEncode, CustomKeyCmp};
 pub use self::txn::{RoTxn, RwTxn};
 use self::cursor::{RoCursor, RwCursor};
 use self::mdb::ffi::{into_val, from_val};

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -1,10 +1,12 @@
 use lmdb_sys as ffi;
 
+pub use ffi::MDB_cmp_func as MDB_cmp_func;
 pub use ffi::MDB_cursor as MDB_cursor;
 pub use ffi::MDB_dbi as MDB_dbi;
 pub use ffi::MDB_env as MDB_env;
 pub use ffi::mdb_filehandle_t as mdb_filehandle_t;
 pub use ffi::MDB_txn as MDB_txn;
+pub use ffi::MDB_val as MDB_val;
 
 pub use ffi::MDB_APPEND as MDB_APPEND;
 pub use ffi::MDB_CP_COMPACT as MDB_CP_COMPACT;
@@ -26,6 +28,7 @@ pub use ffi::mdb_del as mdb_del;
 pub use ffi::mdb_drop as mdb_drop;
 pub use ffi::mdb_get as mdb_get;
 pub use ffi::mdb_put as mdb_put;
+pub use ffi::mdb_set_compare as mdb_set_compare;
 
 pub use ffi::mdb_txn_abort as mdb_txn_abort;
 pub use ffi::mdb_txn_begin as mdb_txn_begin;

--- a/heed/src/mdb/mdbx_ffi.rs
+++ b/heed/src/mdb/mdbx_ffi.rs
@@ -1,10 +1,12 @@
 use mdbx_sys as ffi;
 
+pub use ffi::MDBX_cmp_func as MDBX_cmp_func;
 pub use ffi::MDBX_cursor as MDB_cursor;
 pub use ffi::MDBX_dbi as MDB_dbi;
 pub use ffi::MDBX_env as MDB_env;
 pub use ffi::mdbx_filehandle_t as mdb_filehandle_t;
 pub use ffi::MDBX_txn as MDB_txn;
+pub use ffi::MDBX_val as MDB_val;
 
 pub use ffi::MDBX_APPEND as MDB_APPEND;
 pub use ffi::MDBX_CP_COMPACT as MDB_CP_COMPACT;
@@ -27,6 +29,7 @@ pub use ffi::mdbx_del as mdb_del;
 pub use ffi::mdbx_drop as mdb_drop;
 pub use ffi::mdbx_get as mdb_get;
 pub use ffi::mdbx_put as mdb_put;
+pub use ffi::mdbx_set_compare as mdb_set_compare;
 
 pub use ffi::mdbx_txn_abort as mdb_txn_abort;
 pub use ffi::mdbx_txn_begin as mdb_txn_begin;

--- a/heed/src/mdb/mdbx_ffi.rs
+++ b/heed/src/mdb/mdbx_ffi.rs
@@ -1,6 +1,6 @@
 use mdbx_sys as ffi;
 
-pub use ffi::MDBX_cmp_func as MDBX_cmp_func;
+pub use ffi::MDBX_cmp_func as MDB_cmp_func;
 pub use ffi::MDBX_cursor as MDB_cursor;
 pub use ffi::MDBX_dbi as MDB_dbi;
 pub use ffi::MDBX_env as MDB_env;
@@ -29,7 +29,6 @@ pub use ffi::mdbx_del as mdb_del;
 pub use ffi::mdbx_drop as mdb_drop;
 pub use ffi::mdbx_get as mdb_get;
 pub use ffi::mdbx_put as mdb_put;
-pub use ffi::mdbx_set_compare as mdb_set_compare;
 
 pub use ffi::mdbx_txn_abort as mdb_txn_abort;
 pub use ffi::mdbx_txn_begin as mdb_txn_begin;
@@ -61,4 +60,15 @@ pub unsafe fn into_val(value: &[u8]) -> ffi::MDBX_val {
 
 pub unsafe fn from_val<'a>(value: ffi::MDBX_val) -> &'a [u8] {
     std::slice::from_raw_parts(value.iov_base as *const u8, value.iov_len)
+}
+
+// We create this function just to be compatible with LMDB, it is not meant to be used
+// as the only functions that uses this function are only available for the `lmdb` feature.
+pub unsafe extern "C" fn mdb_set_compare(
+    _txn: *mut MDB_txn,
+    _dbi: MDB_dbi,
+    _cmp: MDB_cmp_func,
+) -> i32
+{
+    super::error::Error::Invalid.to_err_code()
 }


### PR DESCRIPTION
This PR adds some new method for database opening to let the user specify a custom key comparison function if necessary and fixes #86.

- [x] Expose an API to create/open databases with a custom key comparison function.
- [x] Ensure that a database correctly uses a comparison function if it has been open with one.
- [x] Expose a safe Rust API for the user (instead of an `extern "C"` one).
- [x] Move this `CustomKeyCmp` trait into the `heed-trait` crate.
- [x] Ask for a typed function (using the user-defined key codec) instead of a function that takes byte slices.
- [x] Change back the `CustomKeyCmp` trait inputs to be byte slices again, this way we avoid the decoding overheads.
- [x] Make it compile with MDBX but don't let users use that feature as [custom key comparator are deprecated](https://github.com/erthink/libmdbx/blob/adc720816970335d6b7ef85e8a08ddcb336f0dd0/mdbx.h#L3280-L3295).

### Expose a Rust API instead of the LMDB required function signature

The current exposed API for the custom key comparison function is an ugly `extern "C"` function, I would like to let the user give a real Rust function instead. It is ugly in the sense that I don't want to expose the `MDB_val` type (a struct with start and length fields) and therefore the `from_val` function (transform an `MDB_val` into a Rust slice).

```rust
// What the API user must define itself, we give that to LMDB directly.
extern "C" fn my_custom_key_cmp(a: *const MDB_val, b: *const MDB_val) -> i32;

// What I would like to ask the user to give and wrap.
fn my_custom_key_cmp(a: &[u8], b: &[u8]) -> Ordering;

// The wrapper that could be used to call the user defined function,
// transforming a C call into a Rust call, invisible to the API user.
extern "C" fn wrapper(a: *const MDB_val, b: *const MDB_val) -> i32 {
    // transform a and b into Rust slices here using `from_val`.
    // PROBLEM how can I pass the user function here? There is no easy way.
    match (user_cmp_fn)(a, b) {
        Ordering::Less => -1,
        Ordering::Equal => 0,
        Ordering::Greater => 1,
    }
}
```

As it is not quite possible to pass the user-defined function to a wrapper function with [the LMDB required signature](http://www.lmdb.tech/doc/group__mdb.html#gaa8e6e7a6f99bd7142947c48f0c4b970f), I thought that we could maybe be able to "generate" a function with the required signature that is monomorphized to call the user-defined function (no hidden parameter), but is it possible to do that, I am not sure, I tried by using a closure and a [`Box::into_raw` call](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.into_raw), but it didn't work well (`dyn Fn` can't be cast into `extern "C" fn`).

### Ask for a typed key comparison function instead of a function that takes byte slices

The current exposed API asks for a Rust function that takes two bytes slices as arguments and returns an `Ordering`, it is a good enough solution but it would maybe be better to ask for a function that takes decoded types instead, using the database key codec.

```rust
// The trait currently asked the user that is used to compare two keys.
pub trait CustomKeyCmp {
    fn compare(a: &[u8], b: &[u8]) -> Ordering;
}

// The trait that I would like to expose to the user.
pub trait CustomKeyCmp<'t> {
    type Key: 't;
    fn compare(a: Self::Key, b: Self::Key) -> Ordering;
}
```