### PR TITLE
Moving to bytemuck

### DIFF
--- a/Fushia_LICENSE
+++ b/Fushia_LICENSE
@@ -1,0 +1,24 @@
+Copyright 2019 The Fuchsia Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # heed
-A fully typed [LMDB]/[MDBX] wrapper with minimum overhead, uses zerocopy internally.
+A fully typed [LMDB]/[MDBX] wrapper with minimum overhead, uses bytemuck internally.
 
 [![Build Status](https://dev.azure.com/renaultcle/heed/_apis/build/status/Kerollmops.heed?branchName=master)](https://dev.azure.com/renaultcle/heed/_build/latest?definitionId=1&branchName=master)
 [![Dependency Status](https://deps.rs/repo/github/Kerollmops/heed/status.svg)](https://deps.rs/repo/github/Kerollmops/heed)

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -11,9 +11,13 @@ edition = "2018"
 [dependencies]
 bincode = { version = "1.2.1", optional = true }
 bytemuck = { version = "1.5.0", features = ["extern_crate_alloc"] }
+byteorder = "1.4.2"
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 serde = { version = "1.0.117", optional = true }
 serde_json = { version = "1.0.59", optional = true }
+
+[dev-dependencies]
+rand = "0.8.2"
 
 [features]
 default = ["serde-bincode", "serde-json"]

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 
 [dependencies]
 bincode = { version = "1.2.1", optional = true }
+bytemuck = { version = "1.5.0", features = ["extern_crate_alloc"] }
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 serde = { version = "1.0.117", optional = true }
 serde_json = { version = "1.0.59", optional = true }
-zerocopy = "0.3.0"
 
 [features]
 default = ["serde-bincode", "serde-json"]

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
-use std::{mem, ptr};
 
-use crate::aligned_to;
+use bytemuck::{Pod, PodCastError, try_cast_slice, pod_collect_to_vec};
 use heed_traits::{BytesDecode, BytesEncode};
-use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 
 /// Describes a slice that must be [memory aligned] and
 /// will be reallocated if it is not.
@@ -22,47 +20,22 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 /// [`OwnedSlice`]: crate::OwnedSlice
 pub struct CowSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for CowSlice<T>
-where
-    T: AsBytes,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for CowSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
+        try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for CowSlice<T>
-where
-    T: FromBytes + Copy,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for CowSlice<T> {
     type DItem = Cow<'a, [T]>;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
-        match LayoutVerified::<_, [T]>::new_slice(bytes) {
-            Some(layout) => Some(Cow::Borrowed(layout.into_slice())),
-            None => {
-                let len = bytes.len();
-                let elem_size = mem::size_of::<T>();
-
-                // ensure that it is the alignment that is wrong
-                // and the length is valid
-                if len % elem_size == 0 && !aligned_to(bytes, mem::align_of::<T>()) {
-                    let elems = len / elem_size;
-                    let mut vec = Vec::<T>::with_capacity(elems);
-
-                    unsafe {
-                        let dst = vec.as_mut_ptr() as *mut u8;
-                        ptr::copy_nonoverlapping(bytes.as_ptr(), dst, len);
-                        vec.set_len(elems);
-                    }
-
-                    return Some(Cow::Owned(vec));
-                }
-
-                None
-            }
+        match try_cast_slice(bytes) {
+            Ok(items) => Some(Cow::Borrowed(items)),
+            Err(PodCastError::SizeMismatch) => None,
+            Err(_) => Some(Cow::Owned(pod_collect_to_vec(bytes))),
         }
     }
 }

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -20,7 +20,7 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// [`OwnedSlice`]: crate::OwnedSlice
 pub struct CowSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for CowSlice<T> {
+impl<'a, T: Pod> BytesEncode<'a> for CowSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
@@ -28,7 +28,7 @@ impl<'a, T: Pod + 'a> BytesEncode<'a> for CowSlice<T> {
     }
 }
 
-impl<'a, T: Pod + 'a> BytesDecode<'a> for CowSlice<T> {
+impl<'a, T: Pod> BytesDecode<'a> for CowSlice<T> {
     type DItem = Cow<'a, [T]>;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -34,8 +34,8 @@ impl<'a, T: Pod> BytesDecode<'a> for CowSlice<T> {
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
         match try_cast_slice(bytes) {
             Ok(items) => Some(Cow::Borrowed(items)),
-            Err(PodCastError::SizeMismatch) => None,
-            Err(_) => Some(Cow::Owned(pod_collect_to_vec(bytes))),
+            Err(PodCastError::AlignmentMismatch) => Some(Cow::Owned(pod_collect_to_vec(bytes))),
+            Err(_) => None,
         }
     }
 }

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -40,12 +40,12 @@ impl<'a, T: Pod> BytesDecode<'a> for CowType<T> {
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
         match try_from_bytes(bytes) {
             Ok(item) => Some(Cow::Borrowed(item)),
-            Err(PodCastError::SizeMismatch) => None,
-            Err(_) => {
+            Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
                 let mut item = T::zeroed();
                 bytes_of_mut(&mut item).copy_from_slice(bytes);
                 Some(Cow::Owned(item))
             },
+            Err(_) => None,
         }
     }
 }

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -26,7 +26,7 @@ use bytemuck::{Pod, PodCastError, bytes_of, bytes_of_mut, try_from_bytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct CowType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for CowType<T> {
+impl<'a, T: Pod> BytesEncode<'a> for CowType<T> {
     type EItem = T;
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
@@ -34,7 +34,7 @@ impl<'a, T: Pod + 'a> BytesEncode<'a> for CowType<T> {
     }
 }
 
-impl<'a, T: Pod + 'a> BytesDecode<'a> for CowType<T> {
+impl<'a, T: Pod> BytesDecode<'a> for CowType<T> {
     type DItem = Cow<'a, T>;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {

--- a/heed-types/src/integer.rs
+++ b/heed-types/src/integer.rs
@@ -65,9 +65,9 @@ the platform's native endianness.
 `", stringify!($name), "` implements [`Zeroable`], and [`Pod`],
 making it useful for parsing and serialization.
 
-[`new`]: crate::byteorder::", stringify!($name), "::new
-[`get`]: crate::byteorder::", stringify!($name), "::get
-[`set`]: crate::byteorder::", stringify!($name), "::set
+[`new`]: crate::integer::", stringify!($name), "::new
+[`get`]: crate::integer::", stringify!($name), "::get
+[`set`]: crate::integer::", stringify!($name), "::set
 [`Zeroable`]: bytemuck::Zeroable
 [`Pod`]: bytemuck::Pod"),
             #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]

--- a/heed-types/src/integer.rs
+++ b/heed-types/src/integer.rs
@@ -1,0 +1,337 @@
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the Fushia_LICENSE file.
+
+//! Byte order-aware numeric primitives.
+//!
+//! This module contains equivalents of the native multi-byte integer types with
+//! no alignment requirement and supporting byte order conversions.
+//!
+//! For each native multi-byte integer type - `u16`, `i16`, `u32`, etc - an
+//! equivalent type is defined by this module - [`U16`], [`I16`], [`U32`], etc.
+//! Unlike their native counterparts, these types have alignment 1, and take a
+//! type parameter specifying the byte order in which the bytes are stored in
+//! memory. Each type implements the [`Zeroable`], and [`Pod`] traits.
+//!
+//! These two properties, taken together, make these types very useful for
+//! defining data structures whose memory layout matches a wire format such as
+//! that of a network protocol or a file format. Such formats often have
+//! multi-byte values at offsets that do not respect the alignment requirements
+//! of the equivalent native types, and stored in a byte order not necessarily
+//! the same as that of the target platform.
+
+use std::fmt::{self, Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
+use std::marker::PhantomData;
+
+use bytemuck::{Zeroable, Pod};
+use byteorder::ByteOrder;
+
+macro_rules! impl_fmt_trait {
+    ($name:ident, $native:ident, $trait:ident) => {
+        impl<O: ByteOrder> $trait for $name<O> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                $trait::fmt(&self.get(), f)
+            }
+        }
+    };
+}
+
+macro_rules! doc_comment {
+    ($x:expr, $($tt:tt)*) => {
+        #[doc = $x]
+        $($tt)*
+    };
+}
+
+macro_rules! define_type {
+    ($article:ident, $name:ident, $native:ident, $bits:expr, $bytes:expr, $read_method:ident, $write_method:ident, $sign:ident) => {
+        doc_comment! {
+            concat!("A ", stringify!($bits), "-bit ", stringify!($sign), " integer
+stored in `O` byte order.
+
+`", stringify!($name), "` is like the native `", stringify!($native), "` type with
+two major differences: First, it has no alignment requirement (its alignment is 1).
+Second, the endianness of its memory layout is given by the type parameter `O`.
+
+", stringify!($article), " `", stringify!($name), "` can be constructed using
+the [`new`] method, and its contained value can be obtained as a native
+`",stringify!($native), "` using the [`get`] method, or updated in place with
+the [`set`] method. In all cases, if the endianness `O` is not the same as the
+endianness of the current platform, an endianness swap will be performed in
+order to uphold the invariants that a) the layout of `", stringify!($name), "`
+has endianness `O` and that, b) the layout of `", stringify!($native), "` has
+the platform's native endianness.
+
+`", stringify!($name), "` implements [`Zeroable`], and [`Pod`],
+making it useful for parsing and serialization.
+
+[`new`]: crate::byteorder::", stringify!($name), "::new
+[`get`]: crate::byteorder::", stringify!($name), "::get
+[`set`]: crate::byteorder::", stringify!($name), "::set
+[`Zeroable`]: bytemuck::Zeroable
+[`Pod`]: bytemuck::Pod"),
+            #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+            #[repr(transparent)]
+            pub struct $name<O: ByteOrder>([u8; $bytes], PhantomData<O>);
+        }
+
+        unsafe impl<O: ByteOrder> Zeroable for $name<O> {
+            fn zeroed() -> $name<O> {
+                $name([0u8; $bytes], PhantomData)
+            }
+        }
+
+        unsafe impl<O: 'static + ByteOrder> Pod for $name<O> {}
+
+        impl<O: ByteOrder> $name<O> {
+            // TODO(joshlf): Make these const fns if the ByteOrder methods ever
+            // become const fns.
+
+            /// Constructs a new value, possibly performing an endianness swap
+            /// to guarantee that the returned value has endianness `O`.
+            pub fn new(n: $native) -> $name<O> {
+                let mut out = $name::default();
+                O::$write_method(&mut out.0[..], n);
+                out
+            }
+
+            /// Returns the value as a primitive type, possibly performing an
+            /// endianness swap to guarantee that the return value has the
+            /// endianness of the native platform.
+            pub fn get(self) -> $native {
+                O::$read_method(&self.0[..])
+            }
+
+            /// Updates the value in place as a primitive type, possibly
+            /// performing an endianness swap to guarantee that the stored value
+            /// has the endianness `O`.
+            pub fn set(&mut self, n: $native) {
+                O::$write_method(&mut self.0[..], n);
+            }
+        }
+
+        // NOTE: The reasoning behind which traits to implement here is a) only
+        // implement traits which do not involve implicit endianness swaps and,
+        // b) only implement traits which won't cause inference issues. Most of
+        // the traits which would cause inference issues would also involve
+        // endianness swaps anyway (like comparison/ordering with the native
+        // representation or conversion from/to that representation). Note that
+        // we make an exception for the format traits since the cost of
+        // formatting dwarfs cost of performing an endianness swap, and they're
+        // very useful.
+
+        impl<O: ByteOrder> From<$name<O>> for [u8; $bytes] {
+            fn from(x: $name<O>) -> [u8; $bytes] {
+                x.0
+            }
+        }
+
+        impl<O: ByteOrder> From<[u8; $bytes]> for $name<O> {
+            fn from(bytes: [u8; $bytes]) -> $name<O> {
+                $name(bytes, PhantomData)
+            }
+        }
+
+        impl<O: ByteOrder> AsRef<[u8; $bytes]> for $name<O> {
+            fn as_ref(&self) -> &[u8; $bytes] {
+                &self.0
+            }
+        }
+
+        impl<O: ByteOrder> AsMut<[u8; $bytes]> for $name<O> {
+            fn as_mut(&mut self) -> &mut [u8; $bytes] {
+                &mut self.0
+            }
+        }
+
+        impl<O: ByteOrder> PartialEq<$name<O>> for [u8; $bytes] {
+            fn eq(&self, other: &$name<O>) -> bool {
+                self.eq(&other.0)
+            }
+        }
+
+        impl<O: ByteOrder> PartialEq<[u8; $bytes]> for $name<O> {
+            fn eq(&self, other: &[u8; $bytes]) -> bool {
+                self.0.eq(other)
+            }
+        }
+
+        impl_fmt_trait!($name, $native, Display);
+        impl_fmt_trait!($name, $native, Octal);
+        impl_fmt_trait!($name, $native, LowerHex);
+        impl_fmt_trait!($name, $native, UpperHex);
+        impl_fmt_trait!($name, $native, Binary);
+
+        impl<O: ByteOrder> Debug for $name<O> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                // This results in a format like "U16(42)"
+                write!(f, concat!(stringify!($name), "({})"), self.get())
+            }
+        }
+    };
+}
+
+define_type!(A, U16, u16, 16, 2, read_u16, write_u16, unsigned);
+define_type!(A, U32, u32, 32, 4, read_u32, write_u32, unsigned);
+define_type!(A, U64, u64, 64, 8, read_u64, write_u64, unsigned);
+define_type!(A, U128, u128, 128, 16, read_u128, write_u128, unsigned);
+define_type!(An, I16, i16, 16, 2, read_i16, write_i16, signed);
+define_type!(An, I32, i32, 32, 4, read_i32, write_i32, signed);
+define_type!(An, I64, i64, 64, 8, read_i64, write_i64, signed);
+define_type!(An, I128, i128, 128, 16, read_i128, write_i128, signed);
+
+#[cfg(test)]
+mod tests {
+    use byteorder::NativeEndian;
+    use bytemuck::{Pod, bytes_of, bytes_of_mut};
+
+    use super::*;
+
+    // A native integer type (u16, i32, etc)
+    trait Native: Pod + Copy + Eq + Debug {
+        fn rand() -> Self;
+    }
+
+    trait ByteArray: Pod + Copy + AsRef<[u8]> + AsMut<[u8]> + Debug + Default + Eq {
+        /// Invert the order of the bytes in the array.
+        fn invert(self) -> Self;
+    }
+
+    trait ByteOrderType: Pod + Copy + Eq + Debug {
+        type Native: Native;
+        type ByteArray: ByteArray;
+
+        fn new(native: Self::Native) -> Self;
+        fn get(self) -> Self::Native;
+        fn set(&mut self, native: Self::Native);
+        fn from_bytes(bytes: Self::ByteArray) -> Self;
+        fn into_bytes(self) -> Self::ByteArray;
+    }
+
+    macro_rules! impl_byte_array {
+        ($bytes:expr) => {
+            impl ByteArray for [u8; $bytes] {
+                fn invert(mut self) -> [u8; $bytes] {
+                    self.reverse();
+                    self
+                }
+            }
+        };
+    }
+
+    impl_byte_array!(2);
+    impl_byte_array!(4);
+    impl_byte_array!(8);
+    impl_byte_array!(16);
+
+    macro_rules! impl_traits {
+        ($name:ident, $native:ident, $bytes:expr, $sign:ident) => {
+            impl Native for $native {
+                fn rand() -> $native {
+                    rand::random()
+                }
+            }
+
+            impl<O: 'static + ByteOrder> ByteOrderType for $name<O> {
+                type Native = $native;
+                type ByteArray = [u8; $bytes];
+
+                fn new(native: $native) -> $name<O> {
+                    $name::new(native)
+                }
+
+                fn get(self) -> $native {
+                    $name::get(self)
+                }
+
+                fn set(&mut self, native: $native) {
+                    $name::set(self, native)
+                }
+
+                fn from_bytes(bytes: [u8; $bytes]) -> $name<O> {
+                    $name::from(bytes)
+                }
+
+                fn into_bytes(self) -> [u8; $bytes] {
+                    <[u8; $bytes]>::from(self)
+                }
+            }
+        };
+    }
+
+    impl_traits!(U16, u16, 2, unsigned);
+    impl_traits!(U32, u32, 4, unsigned);
+    impl_traits!(U64, u64, 8, unsigned);
+    impl_traits!(U128, u128, 16, unsigned);
+    impl_traits!(I16, i16, 2, signed);
+    impl_traits!(I32, i32, 4, signed);
+    impl_traits!(I64, i64, 8, signed);
+    impl_traits!(I128, i128, 16, signed);
+
+    macro_rules! call_for_all_types {
+        ($fn:ident, $byteorder:ident) => {
+            $fn::<U16<$byteorder>>();
+            $fn::<U32<$byteorder>>();
+            $fn::<U64<$byteorder>>();
+            $fn::<U128<$byteorder>>();
+            $fn::<I16<$byteorder>>();
+            $fn::<I32<$byteorder>>();
+            $fn::<I64<$byteorder>>();
+            $fn::<I128<$byteorder>>();
+        };
+    }
+
+    #[cfg(target_endian = "big")]
+    type NonNativeEndian = byteorder::LittleEndian;
+    #[cfg(target_endian = "little")]
+    type NonNativeEndian = byteorder::BigEndian;
+
+    #[test]
+    fn test_native_endian() {
+        fn test_native_endian<T: ByteOrderType>() {
+            for _ in 0..1024 {
+                let native = T::Native::rand();
+                let mut bytes = T::ByteArray::default();
+                bytes_of_mut(&mut bytes).copy_from_slice(bytes_of(&native));
+                let mut from_native = T::new(native);
+                let from_bytes = T::from_bytes(bytes);
+                assert_eq!(from_native, from_bytes);
+                assert_eq!(from_native.get(), native);
+                assert_eq!(from_bytes.get(), native);
+                assert_eq!(from_native.into_bytes(), bytes);
+                assert_eq!(from_bytes.into_bytes(), bytes);
+
+                let updated = T::Native::rand();
+                from_native.set(updated);
+                assert_eq!(from_native.get(), updated);
+            }
+        }
+
+        call_for_all_types!(test_native_endian, NativeEndian);
+    }
+
+    #[test]
+    fn test_non_native_endian() {
+        fn test_non_native_endian<T: ByteOrderType>() {
+            for _ in 0..1024 {
+                let native = T::Native::rand();
+                let mut bytes = T::ByteArray::default();
+                bytes_of_mut(&mut bytes).copy_from_slice(bytes_of(&native));
+                bytes = bytes.invert();
+                let mut from_native = T::new(native);
+                let from_bytes = T::from_bytes(bytes);
+                assert_eq!(from_native, from_bytes);
+                assert_eq!(from_native.get(), native);
+                assert_eq!(from_bytes.get(), native);
+                assert_eq!(from_native.into_bytes(), bytes);
+                assert_eq!(from_bytes.into_bytes(), bytes);
+
+                let updated = T::Native::rand();
+                from_native.set(updated);
+                assert_eq!(from_native.get(), updated);
+            }
+        }
+
+        call_for_all_types!(test_non_native_endian, NonNativeEndian);
+    }
+}

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -18,19 +18,6 @@
 //! | [`UnalignedSlice`] | `&[T]`        | `&[T]`        | will _never_ allocate because alignement is always valid |
 //! | [`UnalignedType`]  | `&T`          | `&T`          | will _never_ allocate because alignement is always valid |
 //!
-//! Note that **all** those types above must implement [`AsBytes`] and [`FromBytes`]. <br/>
-//! The `UnalignedSlice/Type` types also need to implement the [`Unaligned`] trait.
-//!
-//! If you don't want to/cannot deal with `AsBytes`, `Frombytes` or `Unaligned` requirements
-//! we recommend you to use the `SerdeBincode` or `SerdeJson` types and deal with the `Serialize`/`Deserialize` traits.
-//!
-//! [`AsBytes`]: zerocopy::AsBytes
-//! [`FromBytes`]: zerocopy::FromBytes
-//! [`Unaligned`]: zerocopy::Unaligned
-//!
-//! [`Serialize`]: serde::Serialize
-//! [`Deserialize`]: serde::Deserialize
-//!
 
 mod cow_slice;
 mod cow_type;
@@ -81,7 +68,3 @@ pub use self::serde_bincode::SerdeBincode;
 
 #[cfg(feature = "serde-json")]
 pub use self::serde_json::SerdeJson;
-
-fn aligned_to(bytes: &[u8], align: usize) -> bool {
-    (bytes as *const _ as *const () as usize) % align == 0
-}

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -18,6 +18,8 @@
 //! | [`UnalignedSlice`] | `&[T]`        | `&[T]`        | will _never_ allocate because alignement is always valid |
 //! | [`UnalignedType`]  | `&T`          | `&T`          | will _never_ allocate because alignement is always valid |
 //!
+//! [`Serialize`]: serde::Serialize
+//! [`Deserialize`]: serde::Deserialize
 
 mod cow_slice;
 mod cow_type;

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -27,6 +27,7 @@ mod str;
 mod unaligned_slice;
 mod unaligned_type;
 mod unit;
+pub mod integer;
 
 #[cfg(feature = "serde-bincode")]
 mod serde_bincode;
@@ -36,6 +37,7 @@ mod serde_json;
 
 pub use self::cow_slice::CowSlice;
 pub use self::cow_type::CowType;
+pub use self::integer::*;
 pub use self::owned_slice::OwnedSlice;
 pub use self::owned_type::OwnedType;
 pub use self::str::Str;

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -20,7 +20,7 @@ use crate::CowSlice;
 /// [`CowType`]: crate::CowType
 pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedSlice<T> {
+impl<'a, T: Pod> BytesEncode<'a> for OwnedSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
@@ -28,7 +28,7 @@ impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedSlice<T> {
     }
 }
 
-impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedSlice<T> {
+impl<'a, T: Pod> BytesDecode<'a> for OwnedSlice<T> {
     type DItem = Vec<T>;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-use zerocopy::{AsBytes, FromBytes};
+use bytemuck::Pod;
+use heed_traits::{BytesDecode, BytesEncode};
 
 use crate::CowSlice;
-use heed_traits::{BytesDecode, BytesEncode};
 
 /// Describes a [`Vec`] of types that are totally owned (doesn't
 /// hold any reference to the original slice).
@@ -20,25 +20,19 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// [`CowType`]: crate::CowType
 pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for OwnedSlice<T>
-where
-    T: AsBytes,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
+        CowSlice::bytes_encode(item)
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for OwnedSlice<T>
-where
-    T: FromBytes + Copy,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedSlice<T> {
     type DItem = Vec<T>;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {
-        CowSlice::<T>::bytes_decode(bytes).map(Cow::into_owned)
+        CowSlice::bytes_decode(bytes).map(Cow::into_owned)
     }
 }
 

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -26,7 +26,7 @@ use crate::CowType;
 /// [`CowSlice`]: crate::CowSlice
 pub struct OwnedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedType<T> {
+impl<'a, T: Pod> BytesEncode<'a> for OwnedType<T> {
     type EItem = T;
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
@@ -34,7 +34,7 @@ impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedType<T> {
     }
 }
 
-impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedType<T> {
+impl<'a, T: Pod> BytesDecode<'a> for OwnedType<T> {
     type DItem = T;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use crate::CowType;
 use heed_traits::{BytesDecode, BytesEncode};
-use zerocopy::{AsBytes, FromBytes};
+use bytemuck::Pod;
+
+use crate::CowType;
 
 /// Describes a type that is totally owned (doesn't
 /// hold any reference to the original slice).
@@ -25,21 +26,15 @@ use zerocopy::{AsBytes, FromBytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct OwnedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for OwnedType<T>
-where
-    T: AsBytes,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedType<T> {
     type EItem = T;
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<T as AsBytes>::as_bytes(item)))
+        CowType::bytes_encode(item)
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for OwnedType<T>
-where
-    T: FromBytes + Copy,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedType<T> {
     type DItem = T;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -1,6 +1,9 @@
-use crate::UnalignedSlice;
-use heed_traits::{BytesDecode, BytesEncode};
 use std::borrow::Cow;
+use std::str;
+
+use heed_traits::{BytesDecode, BytesEncode};
+
+use crate::UnalignedSlice;
 
 /// Describes an [`str`].
 pub struct Str;
@@ -17,6 +20,6 @@ impl<'a> BytesDecode<'a> for Str {
     type DItem = &'a str;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
-        std::str::from_utf8(bytes).ok()
+        str::from_utf8(bytes).ok()
     }
 }

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -5,7 +5,7 @@ use heed_traits::{BytesDecode, BytesEncode};
 
 use crate::UnalignedSlice;
 
-/// Describes an [`str`].
+/// Describes an [`prim@str`].
 pub struct Str;
 
 impl BytesEncode<'_> for Str {

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -13,7 +13,7 @@ use bytemuck::{Pod, try_cast_slice};
 /// [`CowType`]: crate::CowType
 pub struct UnalignedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedSlice<T> {
+impl<'a, T: Pod> BytesEncode<'a> for UnalignedSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
@@ -21,7 +21,7 @@ impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedSlice<T> {
     }
 }
 
-impl<'a, T: Pod + 'a> BytesDecode<'a> for UnalignedSlice<T> {
+impl<'a, T: Pod> BytesDecode<'a> for UnalignedSlice<T> {
     type DItem = &'a [T];
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use heed_traits::{BytesDecode, BytesEncode};
-use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};
+use bytemuck::{Pod, try_cast_slice};
 
 /// Describes a type that is totally borrowed and doesn't
 /// depends on any [memory alignment].
@@ -13,25 +13,19 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};
 /// [`CowType`]: crate::CowType
 pub struct UnalignedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for UnalignedSlice<T>
-where
-    T: AsBytes + Unaligned,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
+        try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for UnalignedSlice<T>
-where
-    T: FromBytes + Unaligned,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for UnalignedSlice<T> {
     type DItem = &'a [T];
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
-        LayoutVerified::<_, [T]>::new_slice_unaligned(bytes).map(LayoutVerified::into_slice)
+        try_cast_slice(bytes).ok()
     }
 }
 

--- a/heed-types/src/unaligned_type.rs
+++ b/heed-types/src/unaligned_type.rs
@@ -19,7 +19,7 @@ use bytemuck::{Pod, bytes_of, try_from_bytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct UnalignedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedType<T> {
+impl<'a, T: Pod> BytesEncode<'a> for UnalignedType<T> {
     type EItem = T;
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
@@ -27,7 +27,7 @@ impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedType<T> {
     }
 }
 
-impl<'a, T: Pod + 'a> BytesDecode<'a> for UnalignedType<T> {
+impl<'a, T: Pod> BytesDecode<'a> for UnalignedType<T> {
     type DItem = &'a T;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -25,6 +25,7 @@ synchronoise = "1.0.0"
 
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
+bytemuck = { version = "1.5.0", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 url = "2.2.0"

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
+bytemuck = "1.4.1"
 byteorder = { version = "1.3.4", default-features = false }
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 heed-types = { version = "0.7.2", path = "../heed-types" }
@@ -21,7 +22,6 @@ once_cell = "1.5.2"
 page_size = "0.4.2"
 serde = { version = "1.0.118", features = ["derive"], optional = true }
 synchronoise = "1.0.0"
-zerocopy = "0.3.0"
 
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
-bytemuck = "1.4.1"
+bytemuck = "1.5.0"
 byteorder = { version = "1.3.4", default-features = false }
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 heed-types = { version = "0.7.2", path = "../heed-types" }

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -72,19 +72,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     wtxn.commit()?;
 
     // it is prefered to use zerocopy when possible
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Zeroable, Pod)]
     #[repr(C)]
     struct ZeroBytes {
         bytes: [u8; 12],
     }
-
-    unsafe impl Zeroable for ZeroBytes {
-        fn zeroed() -> Self {
-            ZeroBytes { bytes: Default::default() }
-        }
-    }
-
-    unsafe impl Pod for ZeroBytes { }
 
     let db: Database<Str, UnalignedType<ZeroBytes>> =
         env.create_database(Some("zerocopy-struct"))?;

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     wtxn.commit()?;
 
-    // it is prefered to use zerocopy when possible
+    // it is prefered to use bytemuck when possible
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Zeroable, Pod)]
     #[repr(C)]
     struct ZeroBytes {
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let db: Database<Str, UnalignedType<ZeroBytes>> =
-        env.create_database(Some("zerocopy-struct"))?;
+        env.create_database(Some("simple-struct"))?;
 
     let mut wtxn = env.write_txn()?;
 

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -22,7 +22,7 @@ use crate::types::DecodeIgnore;
 /// # use heed::EnvOpenOptions;
 /// use heed::Database;
 /// use heed::types::*;
-/// use heed::{zerocopy::I64, byteorder::BigEndian};
+/// use heed::byteorder::BigEndian;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -69,7 +69,7 @@ use crate::types::DecodeIgnore;
 /// # use heed::EnvOpenOptions;
 /// use heed::Database;
 /// use heed::types::*;
-/// use heed::{zerocopy::I64, byteorder::BigEndian};
+/// use heed::byteorder::BigEndian;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -265,7 +265,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -333,7 +333,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -405,7 +405,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -476,7 +476,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -541,7 +541,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -594,7 +594,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -643,7 +643,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -699,7 +699,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -746,7 +746,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -787,7 +787,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -841,7 +841,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -883,7 +883,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -939,7 +939,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1017,7 +1017,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1108,7 +1108,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1186,7 +1186,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1277,7 +1277,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1332,7 +1332,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1400,7 +1400,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1455,7 +1455,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1520,7 +1520,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1583,7 +1583,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1645,7 +1645,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1716,7 +1716,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1780,7 +1780,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1828,7 +1828,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -25,11 +25,11 @@ use crate::types::DecodeIgnore;
 /// use heed::byteorder::BigEndian;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+/// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
 /// # let env = EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
-/// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+/// #     .open(Path::new("target").join("database.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
@@ -72,11 +72,11 @@ use crate::types::DecodeIgnore;
 /// use heed::byteorder::BigEndian;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+/// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
 /// # let env = EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
-/// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+/// #     .open(Path::new("target").join("database.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
@@ -199,11 +199,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::types::*;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// let db: Database<Str, OwnedType<i32>> = env.create_database(Some("get-i32"))?;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -268,11 +268,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
@@ -336,11 +336,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
@@ -408,11 +408,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
@@ -479,11 +479,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
@@ -544,11 +544,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("first-i32"))?;
@@ -597,11 +597,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("last-i32"))?;
@@ -646,11 +646,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -702,11 +702,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -749,11 +749,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -790,11 +790,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -844,11 +844,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -886,11 +886,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -942,11 +942,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1020,11 +1020,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1111,11 +1111,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1189,11 +1189,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1280,11 +1280,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
@@ -1335,11 +1335,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
@@ -1403,11 +1403,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
@@ -1458,11 +1458,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
@@ -1523,11 +1523,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1586,11 +1586,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1648,11 +1648,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1719,11 +1719,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1783,11 +1783,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
@@ -1831,11 +1831,11 @@ impl<KC, DC> Database<KC, DC> {
     /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// # fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// # let env = EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
+    /// #     .open(Path::new("target").join("database.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let db: Database<Unit, Unit> = env.create_database(Some("iter-i32"))?;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -99,7 +99,7 @@ impl EnvOpenOptions {
         self
     }
 
-    /// Set one or more LMDB flags (see http://www.lmdb.tech/doc/group__mdb__env.html).
+    /// Set one or [more LMDB flags](http://www.lmdb.tech/doc/group__mdb__env.html).
     /// ```
     /// use std::fs;
     /// use std::path::Path;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -108,13 +108,13 @@ impl EnvOpenOptions {
     /// use heed::flags::Flags;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
+    /// fs::create_dir_all(Path::new("target").join("database.mdb"))?;
     /// let mut env_builder = EnvOpenOptions::new();
     /// unsafe {
     ///     env_builder.flag(Flags::MdbNoTls);
     ///     env_builder.flag(Flags::MdbNoMetaSync);
     /// }
-    /// let env = env_builder.open(Path::new("target").join("zerocopy.mdb"))?;
+    /// let env = env_builder.open(Path::new("target").join("database.mdb"))?;
     ///
     /// // we will open the default unamed database
     /// let db: Database<Str, OwnedType<i32>> = env.create_database(None)?;

--- a/heed/src/iter/mod.rs
+++ b/heed/src/iter/mod.rs
@@ -59,8 +59,8 @@ mod tests {
         use std::fs;
         use std::path::Path;
         use crate::EnvOpenOptions;
+        use crate::byteorder::BigEndian;
         use crate::types::*;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
 
         fs::create_dir_all(Path::new("target").join("iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
@@ -124,7 +124,7 @@ mod tests {
         use std::fs;
         use std::path::Path;
         use crate::EnvOpenOptions;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+        use crate::byteorder::BigEndian;
         use crate::types::*;
 
         fs::create_dir_all(Path::new("target").join("iter_last.mdb")).unwrap();
@@ -305,7 +305,7 @@ mod tests {
         use std::fs;
         use std::path::Path;
         use crate::EnvOpenOptions;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+        use crate::byteorder::BigEndian;
         use crate::types::*;
 
         fs::create_dir_all(Path::new("target").join("range_iter_last.mdb")).unwrap();

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -1,11 +1,11 @@
 //! Crate `heed` is a high-level wrapper of [LMDB], high-level doesn't mean heavy (think about Rust).
 //!
 //! It provides you a way to store types in LMDB without any limit and with a minimal overhead as possible,
-//! relying on the [zerocopy] library to avoid copying bytes when that's unnecessary and the serde library
+//! relying on the [bytemuck] library to avoid copying bytes when that's unnecessary and the serde library
 //! when this is unavoidable.
 //!
 //! The Lightning Memory-Mapped Database (LMDB) directly maps files parts into main memory, combined
-//! with the zerocopy library allows us to safely zero-copy parse and serialize Rust types into LMDB.
+//! with the bytemuck library allows us to safely zero-copy parse and serialize Rust types into LMDB.
 //!
 //! [LMDB]: https://en.wikipedia.org/wiki/Lightning_Memory-Mapped_Database
 //!
@@ -21,8 +21,8 @@
 //! use heed::types::*;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
-//! let env = EnvOpenOptions::new().open(Path::new("target").join("zerocopy.mdb"))?;
+//! fs::create_dir_all(Path::new("target").join("bytemuck.mdb"))?;
+//! let env = EnvOpenOptions::new().open(Path::new("target").join("bytemuck.mdb"))?;
 //!
 //! // we will open the default unamed database
 //! let db: Database<Str, OwnedType<i32>> = env.create_database(None)?;

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -55,9 +55,9 @@ mod lazy_decode;
 mod mdb;
 mod txn;
 
+pub use bytemuck;
 pub use byteorder;
 pub use heed_types as types;
-pub use zerocopy;
 use heed_traits as traits;
 
 pub use self::database::Database;


### PR DESCRIPTION
Fixes #82 by implementing all of the codecs by using the bytemuck crate and copying the code used in zerocopy and made by @joshlf for the integer types (I licensed the code by adding the Fushia_LICENSE at the root of the repository).

This PR will help #89 return appropriate errors [when alignment is wrong, for example](https://docs.rs/bytemuck/1.5.0/bytemuck/enum.PodCastError.html).