### PR TITLE
Better working bytes encoding trait

### DIFF
--- a/Fushia_LICENSE
+++ b/Fushia_LICENSE
@@ -1,0 +1,24 @@
+Copyright 2019 The Fuchsia Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -1,9 +1,11 @@
+#![feature(generic_associated_types)]
+
 use std::borrow::Cow;
 
-pub trait BytesEncode<'a> {
-    type EItem: ?Sized + 'a;
+pub trait BytesEncode {
+    type EItem<'a>;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<'a, [u8]>>;
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>>;
 }
 
 pub trait BytesDecode<'a> {

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -11,9 +11,13 @@ edition = "2018"
 [dependencies]
 bincode = { version = "1.2.1", optional = true }
 bytemuck = { version = "1.5.0", features = ["extern_crate_alloc"] }
+byteorder = "1.4.2"
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 serde = { version = "1.0.117", optional = true }
 serde_json = { version = "1.0.59", optional = true }
+
+[dev-dependencies]
+rand = "0.8.2"
 
 [features]
 default = ["serde-bincode", "serde-json"]

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 
 [dependencies]
 bincode = { version = "1.2.1", optional = true }
+bytemuck = { version = "1.5.0", features = ["extern_crate_alloc"] }
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 serde = { version = "1.0.117", optional = true }
 serde_json = { version = "1.0.59", optional = true }
-zerocopy = "0.3.0"
 
 [features]
 default = ["serde-bincode", "serde-json"]

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
-use std::{mem, ptr};
 
-use crate::aligned_to;
+use bytemuck::{Pod, PodCastError, try_cast_slice, pod_collect_to_vec};
 use heed_traits::{BytesDecode, BytesEncode};
-use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 
 /// Describes a slice that must be [memory aligned] and
 /// will be reallocated if it is not.
@@ -22,47 +20,22 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 /// [`OwnedSlice`]: crate::OwnedSlice
 pub struct CowSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for CowSlice<T>
-where
-    T: AsBytes,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for CowSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
+        try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for CowSlice<T>
-where
-    T: FromBytes + Copy,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for CowSlice<T> {
     type DItem = Cow<'a, [T]>;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
-        match LayoutVerified::<_, [T]>::new_slice(bytes) {
-            Some(layout) => Some(Cow::Borrowed(layout.into_slice())),
-            None => {
-                let len = bytes.len();
-                let elem_size = mem::size_of::<T>();
-
-                // ensure that it is the alignment that is wrong
-                // and the length is valid
-                if len % elem_size == 0 && !aligned_to(bytes, mem::align_of::<T>()) {
-                    let elems = len / elem_size;
-                    let mut vec = Vec::<T>::with_capacity(elems);
-
-                    unsafe {
-                        let dst = vec.as_mut_ptr() as *mut u8;
-                        ptr::copy_nonoverlapping(bytes.as_ptr(), dst, len);
-                        vec.set_len(elems);
-                    }
-
-                    return Some(Cow::Owned(vec));
-                }
-
-                None
-            }
+        match try_cast_slice(bytes) {
+            Ok(items) => Some(Cow::Borrowed(items)),
+            Err(PodCastError::SizeMismatch) => None,
+            Err(_) => Some(Cow::Owned(pod_collect_to_vec(bytes))),
         }
     }
 }

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -20,10 +20,10 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// [`OwnedSlice`]: crate::OwnedSlice
 pub struct CowSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for CowSlice<T> {
-    type EItem = [T];
+impl<T: Pod> BytesEncode for CowSlice<T> {
+    type EItem<'a> = &'a [T];
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -26,11 +26,11 @@ use bytemuck::{Pod, PodCastError, bytes_of, bytes_of_mut, try_from_bytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct CowType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for CowType<T> {
-    type EItem = T;
+impl<T: Pod> BytesEncode for CowType<T> {
+    type EItem<'a> = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(bytes_of(item)))
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
+        Some(Cow::Owned(bytes_of(item).to_vec()))
     }
 }
 

--- a/heed-types/src/integer.rs
+++ b/heed-types/src/integer.rs
@@ -1,0 +1,337 @@
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the Fushia_LICENSE file.
+
+//! Byte order-aware numeric primitives.
+//!
+//! This module contains equivalents of the native multi-byte integer types with
+//! no alignment requirement and supporting byte order conversions.
+//!
+//! For each native multi-byte integer type - `u16`, `i16`, `u32`, etc - an
+//! equivalent type is defined by this module - [`U16`], [`I16`], [`U32`], etc.
+//! Unlike their native counterparts, these types have alignment 1, and take a
+//! type parameter specifying the byte order in which the bytes are stored in
+//! memory. Each type implements the [`Zeroable`], and [`Pod`] traits.
+//!
+//! These two properties, taken together, make these types very useful for
+//! defining data structures whose memory layout matches a wire format such as
+//! that of a network protocol or a file format. Such formats often have
+//! multi-byte values at offsets that do not respect the alignment requirements
+//! of the equivalent native types, and stored in a byte order not necessarily
+//! the same as that of the target platform.
+
+use std::fmt::{self, Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
+use std::marker::PhantomData;
+
+use bytemuck::{Zeroable, Pod};
+use byteorder::ByteOrder;
+
+macro_rules! impl_fmt_trait {
+    ($name:ident, $native:ident, $trait:ident) => {
+        impl<O: ByteOrder> $trait for $name<O> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                $trait::fmt(&self.get(), f)
+            }
+        }
+    };
+}
+
+macro_rules! doc_comment {
+    ($x:expr, $($tt:tt)*) => {
+        #[doc = $x]
+        $($tt)*
+    };
+}
+
+macro_rules! define_type {
+    ($article:ident, $name:ident, $native:ident, $bits:expr, $bytes:expr, $read_method:ident, $write_method:ident, $sign:ident) => {
+        doc_comment! {
+            concat!("A ", stringify!($bits), "-bit ", stringify!($sign), " integer
+stored in `O` byte order.
+
+`", stringify!($name), "` is like the native `", stringify!($native), "` type with
+two major differences: First, it has no alignment requirement (its alignment is 1).
+Second, the endianness of its memory layout is given by the type parameter `O`.
+
+", stringify!($article), " `", stringify!($name), "` can be constructed using
+the [`new`] method, and its contained value can be obtained as a native
+`",stringify!($native), "` using the [`get`] method, or updated in place with
+the [`set`] method. In all cases, if the endianness `O` is not the same as the
+endianness of the current platform, an endianness swap will be performed in
+order to uphold the invariants that a) the layout of `", stringify!($name), "`
+has endianness `O` and that, b) the layout of `", stringify!($native), "` has
+the platform's native endianness.
+
+`", stringify!($name), "` implements [`Zeroable`], and [`Pod`],
+making it useful for parsing and serialization.
+
+[`new`]: crate::byteorder::", stringify!($name), "::new
+[`get`]: crate::byteorder::", stringify!($name), "::get
+[`set`]: crate::byteorder::", stringify!($name), "::set
+[`Zeroable`]: bytemuck::Zeroable
+[`Pod`]: bytemuck::Pod"),
+            #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+            #[repr(transparent)]
+            pub struct $name<O: ByteOrder>([u8; $bytes], PhantomData<O>);
+        }
+
+        unsafe impl<O: ByteOrder> Zeroable for $name<O> {
+            fn zeroed() -> $name<O> {
+                $name([0u8; $bytes], PhantomData)
+            }
+        }
+
+        unsafe impl<O: 'static + ByteOrder> Pod for $name<O> {}
+
+        impl<O: ByteOrder> $name<O> {
+            // TODO(joshlf): Make these const fns if the ByteOrder methods ever
+            // become const fns.
+
+            /// Constructs a new value, possibly performing an endianness swap
+            /// to guarantee that the returned value has endianness `O`.
+            pub fn new(n: $native) -> $name<O> {
+                let mut out = $name::default();
+                O::$write_method(&mut out.0[..], n);
+                out
+            }
+
+            /// Returns the value as a primitive type, possibly performing an
+            /// endianness swap to guarantee that the return value has the
+            /// endianness of the native platform.
+            pub fn get(self) -> $native {
+                O::$read_method(&self.0[..])
+            }
+
+            /// Updates the value in place as a primitive type, possibly
+            /// performing an endianness swap to guarantee that the stored value
+            /// has the endianness `O`.
+            pub fn set(&mut self, n: $native) {
+                O::$write_method(&mut self.0[..], n);
+            }
+        }
+
+        // NOTE: The reasoning behind which traits to implement here is a) only
+        // implement traits which do not involve implicit endianness swaps and,
+        // b) only implement traits which won't cause inference issues. Most of
+        // the traits which would cause inference issues would also involve
+        // endianness swaps anyway (like comparison/ordering with the native
+        // representation or conversion from/to that representation). Note that
+        // we make an exception for the format traits since the cost of
+        // formatting dwarfs cost of performing an endianness swap, and they're
+        // very useful.
+
+        impl<O: ByteOrder> From<$name<O>> for [u8; $bytes] {
+            fn from(x: $name<O>) -> [u8; $bytes] {
+                x.0
+            }
+        }
+
+        impl<O: ByteOrder> From<[u8; $bytes]> for $name<O> {
+            fn from(bytes: [u8; $bytes]) -> $name<O> {
+                $name(bytes, PhantomData)
+            }
+        }
+
+        impl<O: ByteOrder> AsRef<[u8; $bytes]> for $name<O> {
+            fn as_ref(&self) -> &[u8; $bytes] {
+                &self.0
+            }
+        }
+
+        impl<O: ByteOrder> AsMut<[u8; $bytes]> for $name<O> {
+            fn as_mut(&mut self) -> &mut [u8; $bytes] {
+                &mut self.0
+            }
+        }
+
+        impl<O: ByteOrder> PartialEq<$name<O>> for [u8; $bytes] {
+            fn eq(&self, other: &$name<O>) -> bool {
+                self.eq(&other.0)
+            }
+        }
+
+        impl<O: ByteOrder> PartialEq<[u8; $bytes]> for $name<O> {
+            fn eq(&self, other: &[u8; $bytes]) -> bool {
+                self.0.eq(other)
+            }
+        }
+
+        impl_fmt_trait!($name, $native, Display);
+        impl_fmt_trait!($name, $native, Octal);
+        impl_fmt_trait!($name, $native, LowerHex);
+        impl_fmt_trait!($name, $native, UpperHex);
+        impl_fmt_trait!($name, $native, Binary);
+
+        impl<O: ByteOrder> Debug for $name<O> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                // This results in a format like "U16(42)"
+                write!(f, concat!(stringify!($name), "({})"), self.get())
+            }
+        }
+    };
+}
+
+define_type!(A, U16, u16, 16, 2, read_u16, write_u16, unsigned);
+define_type!(A, U32, u32, 32, 4, read_u32, write_u32, unsigned);
+define_type!(A, U64, u64, 64, 8, read_u64, write_u64, unsigned);
+define_type!(A, U128, u128, 128, 16, read_u128, write_u128, unsigned);
+define_type!(An, I16, i16, 16, 2, read_i16, write_i16, signed);
+define_type!(An, I32, i32, 32, 4, read_i32, write_i32, signed);
+define_type!(An, I64, i64, 64, 8, read_i64, write_i64, signed);
+define_type!(An, I128, i128, 128, 16, read_i128, write_i128, signed);
+
+#[cfg(test)]
+mod tests {
+    use byteorder::NativeEndian;
+    use bytemuck::{Pod, bytes_of, bytes_of_mut};
+
+    use super::*;
+
+    // A native integer type (u16, i32, etc)
+    trait Native: Pod + Copy + Eq + Debug {
+        fn rand() -> Self;
+    }
+
+    trait ByteArray: Pod + Copy + AsRef<[u8]> + AsMut<[u8]> + Debug + Default + Eq {
+        /// Invert the order of the bytes in the array.
+        fn invert(self) -> Self;
+    }
+
+    trait ByteOrderType: Pod + Copy + Eq + Debug {
+        type Native: Native;
+        type ByteArray: ByteArray;
+
+        fn new(native: Self::Native) -> Self;
+        fn get(self) -> Self::Native;
+        fn set(&mut self, native: Self::Native);
+        fn from_bytes(bytes: Self::ByteArray) -> Self;
+        fn into_bytes(self) -> Self::ByteArray;
+    }
+
+    macro_rules! impl_byte_array {
+        ($bytes:expr) => {
+            impl ByteArray for [u8; $bytes] {
+                fn invert(mut self) -> [u8; $bytes] {
+                    self.reverse();
+                    self
+                }
+            }
+        };
+    }
+
+    impl_byte_array!(2);
+    impl_byte_array!(4);
+    impl_byte_array!(8);
+    impl_byte_array!(16);
+
+    macro_rules! impl_traits {
+        ($name:ident, $native:ident, $bytes:expr, $sign:ident) => {
+            impl Native for $native {
+                fn rand() -> $native {
+                    rand::random()
+                }
+            }
+
+            impl<O: 'static + ByteOrder> ByteOrderType for $name<O> {
+                type Native = $native;
+                type ByteArray = [u8; $bytes];
+
+                fn new(native: $native) -> $name<O> {
+                    $name::new(native)
+                }
+
+                fn get(self) -> $native {
+                    $name::get(self)
+                }
+
+                fn set(&mut self, native: $native) {
+                    $name::set(self, native)
+                }
+
+                fn from_bytes(bytes: [u8; $bytes]) -> $name<O> {
+                    $name::from(bytes)
+                }
+
+                fn into_bytes(self) -> [u8; $bytes] {
+                    <[u8; $bytes]>::from(self)
+                }
+            }
+        };
+    }
+
+    impl_traits!(U16, u16, 2, unsigned);
+    impl_traits!(U32, u32, 4, unsigned);
+    impl_traits!(U64, u64, 8, unsigned);
+    impl_traits!(U128, u128, 16, unsigned);
+    impl_traits!(I16, i16, 2, signed);
+    impl_traits!(I32, i32, 4, signed);
+    impl_traits!(I64, i64, 8, signed);
+    impl_traits!(I128, i128, 16, signed);
+
+    macro_rules! call_for_all_types {
+        ($fn:ident, $byteorder:ident) => {
+            $fn::<U16<$byteorder>>();
+            $fn::<U32<$byteorder>>();
+            $fn::<U64<$byteorder>>();
+            $fn::<U128<$byteorder>>();
+            $fn::<I16<$byteorder>>();
+            $fn::<I32<$byteorder>>();
+            $fn::<I64<$byteorder>>();
+            $fn::<I128<$byteorder>>();
+        };
+    }
+
+    #[cfg(target_endian = "big")]
+    type NonNativeEndian = byteorder::LittleEndian;
+    #[cfg(target_endian = "little")]
+    type NonNativeEndian = byteorder::BigEndian;
+
+    #[test]
+    fn test_native_endian() {
+        fn test_native_endian<T: ByteOrderType>() {
+            for _ in 0..1024 {
+                let native = T::Native::rand();
+                let mut bytes = T::ByteArray::default();
+                bytes_of_mut(&mut bytes).copy_from_slice(bytes_of(&native));
+                let mut from_native = T::new(native);
+                let from_bytes = T::from_bytes(bytes);
+                assert_eq!(from_native, from_bytes);
+                assert_eq!(from_native.get(), native);
+                assert_eq!(from_bytes.get(), native);
+                assert_eq!(from_native.into_bytes(), bytes);
+                assert_eq!(from_bytes.into_bytes(), bytes);
+
+                let updated = T::Native::rand();
+                from_native.set(updated);
+                assert_eq!(from_native.get(), updated);
+            }
+        }
+
+        call_for_all_types!(test_native_endian, NativeEndian);
+    }
+
+    #[test]
+    fn test_non_native_endian() {
+        fn test_non_native_endian<T: ByteOrderType>() {
+            for _ in 0..1024 {
+                let native = T::Native::rand();
+                let mut bytes = T::ByteArray::default();
+                bytes_of_mut(&mut bytes).copy_from_slice(bytes_of(&native));
+                bytes = bytes.invert();
+                let mut from_native = T::new(native);
+                let from_bytes = T::from_bytes(bytes);
+                assert_eq!(from_native, from_bytes);
+                assert_eq!(from_native.get(), native);
+                assert_eq!(from_bytes.get(), native);
+                assert_eq!(from_native.into_bytes(), bytes);
+                assert_eq!(from_bytes.into_bytes(), bytes);
+
+                let updated = T::Native::rand();
+                from_native.set(updated);
+                assert_eq!(from_native.get(), updated);
+            }
+        }
+
+        call_for_all_types!(test_non_native_endian, NonNativeEndian);
+    }
+}

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 //! Types that can be used to serialize and deserialize types inside databases.
 //!
 //! How to choose the right type to store things in this database?

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -18,19 +18,6 @@
 //! | [`UnalignedSlice`] | `&[T]`        | `&[T]`        | will _never_ allocate because alignement is always valid |
 //! | [`UnalignedType`]  | `&T`          | `&T`          | will _never_ allocate because alignement is always valid |
 //!
-//! Note that **all** those types above must implement [`AsBytes`] and [`FromBytes`]. <br/>
-//! The `UnalignedSlice/Type` types also need to implement the [`Unaligned`] trait.
-//!
-//! If you don't want to/cannot deal with `AsBytes`, `Frombytes` or `Unaligned` requirements
-//! we recommend you to use the `SerdeBincode` or `SerdeJson` types and deal with the `Serialize`/`Deserialize` traits.
-//!
-//! [`AsBytes`]: zerocopy::AsBytes
-//! [`FromBytes`]: zerocopy::FromBytes
-//! [`Unaligned`]: zerocopy::Unaligned
-//!
-//! [`Serialize`]: serde::Serialize
-//! [`Deserialize`]: serde::Deserialize
-//!
 
 mod cow_slice;
 mod cow_type;
@@ -81,7 +68,3 @@ pub use self::serde_bincode::SerdeBincode;
 
 #[cfg(feature = "serde-json")]
 pub use self::serde_json::SerdeJson;
-
-fn aligned_to(bytes: &[u8], align: usize) -> bool {
-    (bytes as *const _ as *const () as usize) % align == 0
-}

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -27,6 +27,7 @@ mod str;
 mod unaligned_slice;
 mod unaligned_type;
 mod unit;
+pub mod integer;
 
 #[cfg(feature = "serde-bincode")]
 mod serde_bincode;
@@ -36,6 +37,7 @@ mod serde_json;
 
 pub use self::cow_slice::CowSlice;
 pub use self::cow_type::CowType;
+pub use self::integer::*;
 pub use self::owned_slice::OwnedSlice;
 pub use self::owned_type::OwnedType;
 pub use self::str::Str;

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -20,10 +20,10 @@ use crate::CowSlice;
 /// [`CowType`]: crate::CowType
 pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedSlice<T> {
-    type EItem = [T];
+impl<T: Pod> BytesEncode for OwnedSlice<T> {
+    type EItem<'a> = &'a [T];
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         CowSlice::bytes_encode(item)
     }
 }

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-use zerocopy::{AsBytes, FromBytes};
+use bytemuck::Pod;
+use heed_traits::{BytesDecode, BytesEncode};
 
 use crate::CowSlice;
-use heed_traits::{BytesDecode, BytesEncode};
 
 /// Describes a [`Vec`] of types that are totally owned (doesn't
 /// hold any reference to the original slice).
@@ -20,25 +20,19 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// [`CowType`]: crate::CowType
 pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for OwnedSlice<T>
-where
-    T: AsBytes,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
+        CowSlice::bytes_encode(item)
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for OwnedSlice<T>
-where
-    T: FromBytes + Copy,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedSlice<T> {
     type DItem = Vec<T>;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {
-        CowSlice::<T>::bytes_decode(bytes).map(Cow::into_owned)
+        CowSlice::bytes_decode(bytes).map(Cow::into_owned)
     }
 }
 

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -26,10 +26,10 @@ use crate::CowType;
 /// [`CowSlice`]: crate::CowSlice
 pub struct OwnedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedType<T> {
-    type EItem = T;
+impl<T: Pod> BytesEncode for OwnedType<T> {
+    type EItem<'a> = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         CowType::bytes_encode(item)
     }
 }

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use crate::CowType;
 use heed_traits::{BytesDecode, BytesEncode};
-use zerocopy::{AsBytes, FromBytes};
+use bytemuck::Pod;
+
+use crate::CowType;
 
 /// Describes a type that is totally owned (doesn't
 /// hold any reference to the original slice).
@@ -25,21 +26,15 @@ use zerocopy::{AsBytes, FromBytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct OwnedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for OwnedType<T>
-where
-    T: AsBytes,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for OwnedType<T> {
     type EItem = T;
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<T as AsBytes>::as_bytes(item)))
+        CowType::bytes_encode(item)
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for OwnedType<T>
-where
-    T: FromBytes + Copy,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedType<T> {
     type DItem = T;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {

--- a/heed-types/src/serde_bincode.rs
+++ b/heed-types/src/serde_bincode.rs
@@ -7,13 +7,13 @@ use std::borrow::Cow;
 /// It can borrow bytes from the original slice.
 pub struct SerdeBincode<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for SerdeBincode<T>
+impl<T> BytesEncode for SerdeBincode<T>
 where
     T: Serialize,
 {
-    type EItem = T;
+    type EItem<'a> = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         bincode::serialize(item).map(Cow::Owned).ok()
     }
 }

--- a/heed-types/src/serde_json.rs
+++ b/heed-types/src/serde_json.rs
@@ -7,13 +7,13 @@ use std::borrow::Cow;
 /// It can borrow bytes from the original slice.
 pub struct SerdeJson<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for SerdeJson<T>
+impl<T> BytesEncode for SerdeJson<T>
 where
     T: Serialize,
 {
-    type EItem = T;
+    type EItem<'a> = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         serde_json::to_vec(item).map(Cow::Owned).ok()
     }
 }

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -8,11 +8,11 @@ use crate::UnalignedSlice;
 /// Describes an [`str`].
 pub struct Str;
 
-impl BytesEncode<'_> for Str {
-    type EItem = str;
+impl BytesEncode for Str {
+    type EItem<'a> = &'a str;
 
-    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
-        UnalignedSlice::<u8>::bytes_encode(item.as_bytes())
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
+        UnalignedSlice::<u8>::bytes_encode(&item.as_bytes())
     }
 }
 

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -1,6 +1,9 @@
-use crate::UnalignedSlice;
-use heed_traits::{BytesDecode, BytesEncode};
 use std::borrow::Cow;
+use std::str;
+
+use heed_traits::{BytesDecode, BytesEncode};
+
+use crate::UnalignedSlice;
 
 /// Describes an [`str`].
 pub struct Str;
@@ -17,6 +20,6 @@ impl<'a> BytesDecode<'a> for Str {
     type DItem = &'a str;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
-        std::str::from_utf8(bytes).ok()
+        str::from_utf8(bytes).ok()
     }
 }

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use heed_traits::{BytesDecode, BytesEncode};
-use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};
+use bytemuck::{Pod, try_cast_slice};
 
 /// Describes a type that is totally borrowed and doesn't
 /// depends on any [memory alignment].
@@ -13,25 +13,19 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};
 /// [`CowType`]: crate::CowType
 pub struct UnalignedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for UnalignedSlice<T>
-where
-    T: AsBytes + Unaligned,
-{
+impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedSlice<T> {
     type EItem = [T];
 
     fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(<[T] as AsBytes>::as_bytes(item)))
+        try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a, T: 'a> BytesDecode<'a> for UnalignedSlice<T>
-where
-    T: FromBytes + Unaligned,
-{
+impl<'a, T: Pod + 'a> BytesDecode<'a> for UnalignedSlice<T> {
     type DItem = &'a [T];
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
-        LayoutVerified::<_, [T]>::new_slice_unaligned(bytes).map(LayoutVerified::into_slice)
+        try_cast_slice(bytes).ok()
     }
 }
 

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -13,10 +13,10 @@ use bytemuck::{Pod, try_cast_slice};
 /// [`CowType`]: crate::CowType
 pub struct UnalignedSlice<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedSlice<T> {
-    type EItem = [T];
+impl<T: Pod> BytesEncode for UnalignedSlice<T> {
+    type EItem<'a> = &'a [T];
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }

--- a/heed-types/src/unaligned_type.rs
+++ b/heed-types/src/unaligned_type.rs
@@ -19,11 +19,11 @@ use bytemuck::{Pod, bytes_of, try_from_bytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct UnalignedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod + 'a> BytesEncode<'a> for UnalignedType<T> {
-    type EItem = T;
+impl<T: Pod> BytesEncode for UnalignedType<T> {
+    type EItem<'a> = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
-        Some(Cow::Borrowed(bytes_of(item)))
+    fn bytes_encode<'a, 'b>(item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
+        Some(Cow::Owned(bytes_of(item).to_vec()))
     }
 }
 

--- a/heed-types/src/unit.rs
+++ b/heed-types/src/unit.rs
@@ -4,10 +4,10 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// Describes the `()` type.
 pub struct Unit;
 
-impl BytesEncode<'_> for Unit {
-    type EItem = ();
+impl BytesEncode for Unit {
+    type EItem<'a> = ();
 
-    fn bytes_encode(_item: &Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode<'a, 'b>(_item: &'b Self::EItem<'a>) -> Option<Cow<'a, [u8]>> {
         Some(Cow::Borrowed(&[]))
     }
 }

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
+bytemuck = "1.4.1"
 byteorder = { version = "1.3.4", default-features = false }
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 heed-types = { version = "0.7.2", path = "../heed-types" }
@@ -21,7 +22,6 @@ once_cell = "1.5.2"
 page_size = "0.4.2"
 serde = { version = "1.0.118", features = ["derive"], optional = true }
 synchronoise = "1.0.0"
-zerocopy = "0.3.0"
 
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<OwnedType<[i32; 2]>, Str> = env.create_database(Some("kikou"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, [2, 3], "what's up?")?;
+    let _ret = db.put(&mut wtxn, &[2, 3], &"what's up?")?;
     let ret: Option<&str> = db.get(&wtxn, [2, 3])?;
 
     println!("{:?}", ret);
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<Str, ByteSlice> = env.create_database(Some("kiki"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, "hello", &[2, 3][..])?;
+    let _ret = db.put(&mut wtxn, &"hello", &&[2, 3][..])?;
     let ret: Option<&[u8]> = db.get(&wtxn, "hello")?;
 
     println!("{:?}", ret);
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let hello = Hello { string: "hi" };
-    db.put(&mut wtxn, "hello", hello)?;
+    db.put(&mut wtxn, &"hello", &hello)?;
 
     let ret: Option<Hello> = db.get(&wtxn, "hello")?;
     println!("serde-bincode:\t{:?}", ret);
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let hello = Hello { string: "hi" };
-    db.put(&mut wtxn, "hello", hello)?;
+    db.put(&mut wtxn, &"hello", &hello)?;
 
     let ret: Option<Hello> = db.get(&wtxn, "hello")?;
     println!("serde-json:\t{:?}", ret);
@@ -92,7 +92,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let zerobytes = ZeroBytes { bytes: [24; 12] };
-    db.put(&mut wtxn, "zero", zerobytes)?;
+    db.put(&mut wtxn, &"zero", &zerobytes)?;
 
     let ret = db.get(&wtxn, "zero")?;
 
@@ -103,7 +103,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<Str, Unit> = env.create_database(Some("ignored-data"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, "hello", ())?;
+    let _ret = db.put(&mut wtxn, &"hello", &())?;
     let ret: Option<()> = db.get(&wtxn, "hello")?;
 
     println!("{:?}", ret);
@@ -133,10 +133,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, BEI64::new(0), ())?;
-    let _ret = db.put(&mut wtxn, BEI64::new(68), ())?;
-    let _ret = db.put(&mut wtxn, BEI64::new(35), ())?;
-    let _ret = db.put(&mut wtxn, BEI64::new(42), ())?;
+    let _ret = db.put(&mut wtxn, &BEI64::new(0), &())?;
+    let _ret = db.put(&mut wtxn, &BEI64::new(68), &())?;
+    let _ret = db.put(&mut wtxn, &BEI64::new(35), &())?;
+    let _ret = db.put(&mut wtxn, &BEI64::new(42), &())?;
 
     let rets: Result<Vec<(BEI64, _)>, _> = db.iter(&wtxn)?.collect();
 

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -25,8 +25,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<OwnedType<[i32; 2]>, Str> = env.create_database(Some("kikou"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, &[2, 3], "what's up?")?;
-    let ret: Option<&str> = db.get(&wtxn, &[2, 3])?;
+    let _ret = db.put(&mut wtxn, [2, 3], "what's up?")?;
+    let ret: Option<&str> = db.get(&wtxn, [2, 3])?;
 
     println!("{:?}", ret);
     wtxn.commit()?;
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let hello = Hello { string: "hi" };
-    db.put(&mut wtxn, "hello", &hello)?;
+    db.put(&mut wtxn, "hello", hello)?;
 
     let ret: Option<Hello> = db.get(&wtxn, "hello")?;
     println!("serde-bincode:\t{:?}", ret);
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let hello = Hello { string: "hi" };
-    db.put(&mut wtxn, "hello", &hello)?;
+    db.put(&mut wtxn, "hello", hello)?;
 
     let ret: Option<Hello> = db.get(&wtxn, "hello")?;
     println!("serde-json:\t{:?}", ret);
@@ -92,7 +92,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let zerobytes = ZeroBytes { bytes: [24; 12] };
-    db.put(&mut wtxn, "zero", &zerobytes)?;
+    db.put(&mut wtxn, "zero", zerobytes)?;
 
     let ret = db.get(&wtxn, "zero")?;
 
@@ -103,7 +103,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<Str, Unit> = env.create_database(Some("ignored-data"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, "hello", &())?;
+    let _ret = db.put(&mut wtxn, "hello", ())?;
     let ret: Option<()> = db.get(&wtxn, "hello")?;
 
     println!("{:?}", ret);
@@ -133,10 +133,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, &BEI64::new(0), &())?;
-    let _ret = db.put(&mut wtxn, &BEI64::new(68), &())?;
-    let _ret = db.put(&mut wtxn, &BEI64::new(35), &())?;
-    let _ret = db.put(&mut wtxn, &BEI64::new(42), &())?;
+    let _ret = db.put(&mut wtxn, BEI64::new(0), ())?;
+    let _ret = db.put(&mut wtxn, BEI64::new(68), ())?;
+    let _ret = db.put(&mut wtxn, BEI64::new(35), ())?;
+    let _ret = db.put(&mut wtxn, BEI64::new(42), ())?;
 
     let rets: Result<Vec<(BEI64, _)>, _> = db.iter(&wtxn)?.collect();
 
@@ -144,13 +144,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // or iterate over ranges too!!!
     let range = BEI64::new(35)..=BEI64::new(42);
-    let rets: Result<Vec<(BEI64, _)>, _> = db.range(&wtxn, &range)?.collect();
+    let rets: Result<Vec<(BEI64, _)>, _> = db.range(&wtxn, range)?.collect();
 
     println!("{:?}", rets);
 
     // delete a range of key
     let range = BEI64::new(35)..=BEI64::new(42);
-    let deleted: usize = db.delete_range(&mut wtxn, &range)?;
+    let deleted: usize = db.delete_range(&mut wtxn, range)?;
 
     let rets: Result<Vec<(BEI64, _)>, _> = db.iter(&wtxn)?.collect();
 

--- a/heed/examples/clear-database.rs
+++ b/heed/examples/clear-database.rs
@@ -22,14 +22,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     // We fill the db database with entries.
-    db.put(&mut wtxn, "I am here", "to test things")?;
-    db.put(&mut wtxn, "I am here too", "for the same purpose")?;
+    db.put(&mut wtxn, &"I am here", &"to test things")?;
+    db.put(&mut wtxn, &"I am here too", &"for the same purpose")?;
 
     wtxn.commit()?;
 
     let mut wtxn = env.write_txn()?;
     db.clear(&mut wtxn)?;
-    db.put(&mut wtxn, "And I come back", "to test things")?;
+    db.put(&mut wtxn, &"And I come back", &"to test things")?;
 
     let mut iter = db.iter(&wtxn)?;
     assert_eq!(iter.next().transpose()?, Some(("And I come back", "to test things")));

--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -24,8 +24,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     // We fill the first database with entries.
-    first.put(&mut wtxn, "I am here", "to test things")?;
-    first.put(&mut wtxn, "I am here too", "for the same purpose")?;
+    first.put(&mut wtxn, &"I am here", &"to test things")?;
+    first.put(&mut wtxn, &"I am here too", &"for the same purpose")?;
 
     // We try to append ordered entries in the second database.
     let mut iter = second.iter_mut(&mut wtxn)?;

--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -30,9 +30,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // We try to append ordered entries in the second database.
     let mut iter = second.iter_mut(&mut wtxn)?;
 
-    iter.append("aaaa", "lol")?;
-    iter.append("abcd", "lol")?;
-    iter.append("bcde", "lol")?;
+    iter.append(&"aaaa", &"lol")?;
+    iter.append(&"abcd", &"lol")?;
+    iter.append(&"bcde", &"lol")?;
 
     drop(iter);
 

--- a/heed/examples/multi-env.rs
+++ b/heed/examples/multi-env.rs
@@ -38,8 +38,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut wtxn1 = env1.write_txn()?;
 
-    db1.put(&mut wtxn1, "what", &[4, 5][..])?;
-    db1.get(&wtxn1, "what")?;
+    db1.put(&mut wtxn1, &"what", &&[4, 5][..])?;
+    db1.get(&wtxn1, &"what")?;
     wtxn1.commit()?;
 
     let rtxn2 = env2.read_txn()?;

--- a/heed/examples/nested.rs
+++ b/heed/examples/nested.rs
@@ -29,14 +29,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut nwtxn = env.nested_write_txn(&mut wtxn)?;
 
-    db.put(&mut nwtxn, "what", &[4, 5][..])?;
-    let ret = db.get(&nwtxn, "what")?;
+    db.put(&mut nwtxn, &"what", &&[4, 5][..])?;
+    let ret = db.get(&nwtxn, &"what")?;
     println!("nested(1) \"what\": {:?}", ret);
 
     println!("nested(1) abort");
     nwtxn.abort()?;
 
-    let ret = db.get(&wtxn, "what")?;
+    let ret = db.get(&wtxn, &"what")?;
     println!("parent \"what\": {:?}", ret);
 
     // ------
@@ -46,20 +46,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut nwtxn = env.nested_write_txn(&mut wtxn)?;
     let mut nnwtxn = env.nested_write_txn(&mut nwtxn)?;
 
-    db.put(&mut nnwtxn, "humm...", &[6, 7][..])?;
-    let ret = db.get(&nnwtxn, "humm...")?;
+    db.put(&mut nnwtxn, &"humm...", &&[6, 7][..])?;
+    let ret = db.get(&nnwtxn, &"humm...")?;
     println!("nested(2) \"humm...\": {:?}", ret);
 
     println!("nested(2) commit");
     nnwtxn.commit()?;
     nwtxn.commit()?;
 
-    let ret = db.get(&wtxn, "humm...")?;
+    let ret = db.get(&wtxn, &"humm...")?;
     println!("parent \"humm...\": {:?}", ret);
 
-    db.put(&mut wtxn, "hello", &[2, 3][..])?;
+    db.put(&mut wtxn, &"hello", &&[2, 3][..])?;
 
-    let ret = db.get(&wtxn, "hello")?;
+    let ret = db.get(&wtxn, &"hello")?;
     println!("parent \"hello\": {:?}", ret);
 
     println!("parent commit");
@@ -70,10 +70,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let rtxn = env.read_txn()?;
 
-    let ret = db.get(&rtxn, "hello")?;
+    let ret = db.get(&rtxn, &"hello")?;
     println!("parent (reader) \"hello\": {:?}", ret);
 
-    let ret = db.get(&rtxn, "humm...")?;
+    let ret = db.get(&rtxn, &"humm...")?;
     println!("parent (reader) \"humm...\": {:?}", ret);
 
     Ok(())

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -220,7 +220,7 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'a, 'txn, T>(&self, txn: &'txn RoTxn<T>, key: KC::EItem<'a>) -> Result<Option<DC::DItem>>
+    pub fn get<'a, 'b, 'txn, T>(&self, txn: &'txn RoTxn<T>, key: &'b KC::EItem<'a>) -> Result<Option<DC::DItem>>
     where
         KC: BytesEncode,
         DC: BytesDecode<'txn>,
@@ -295,10 +295,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than<'a, 'txn, T>(
+    pub fn get_lower_than<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: KC::EItem<'a>,
+        key: &'b KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesEncode + BytesDecode<'txn>,
@@ -363,10 +363,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_lower_than_or_equal_to<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: KC::EItem<'a>,
+        key: &'b KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesEncode + BytesDecode<'txn>,
@@ -435,10 +435,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than<'a, 'txn, T>(
+    pub fn get_greater_than<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: KC::EItem<'a>,
+        key: &'b KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesEncode + BytesDecode<'txn>,
@@ -506,10 +506,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_greater_than_or_equal_to<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: KC::EItem<'a>,
+        key: &'b KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesEncode + BytesDecode<'txn>,
@@ -1307,16 +1307,16 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter<'a, 'txn, T>(
+    pub fn prefix_iter<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        prefix: KC::EItem<'a>,
+        prefix: &'b KC::EItem<'a>,
     ) -> Result<RoPrefix<'txn, KC, DC>>
     where
         KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RoCursor::new(txn, self.dbi).map(|cursor| RoPrefix::new(cursor, prefix_bytes))
     }
@@ -1375,16 +1375,16 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter_mut<'a, 'txn, T>(
+    pub fn prefix_iter_mut<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        prefix: KC::EItem<'a>,
+        prefix: &'b KC::EItem<'a>,
     ) -> Result<RwPrefix<'txn, KC, DC>>
     where
         KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RwCursor::new(txn, self.dbi).map(|cursor| RwPrefix::new(cursor, prefix_bytes))
     }
@@ -1430,16 +1430,16 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_prefix_iter<'a, 'txn, T>(
+    pub fn rev_prefix_iter<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        prefix: KC::EItem<'a>,
+        prefix: &'b KC::EItem<'a>,
     ) -> Result<RoRevPrefix<'txn, KC, DC>>
     where
         KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RoCursor::new(txn, self.dbi).map(|cursor| RoRevPrefix::new(cursor, prefix_bytes))
     }
@@ -1498,16 +1498,16 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_prefix_iter_mut<'a, 'txn, T>(
+    pub fn rev_prefix_iter_mut<'a, 'b, 'txn, T>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        prefix: KC::EItem<'a>,
+        prefix: &'b KC::EItem<'a>,
     ) -> Result<RwRevPrefix<'txn, KC, DC>>
     where
         KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RwCursor::new(txn, self.dbi).map(|cursor| RwRevPrefix::new(cursor, prefix_bytes))
     }
@@ -1545,15 +1545,15 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn put<'a, T>(&self, txn: &mut RwTxn<T>, key: KC::EItem<'a>, data: DC::EItem<'a>) -> Result<()>
+    pub fn put<'a, 'b, T>(&self, txn: &mut RwTxn<T>, key: &'b KC::EItem<'a>, data: &'b DC::EItem<'a>) -> Result<()>
     where
         KC: BytesEncode,
         DC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).ok_or(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).ok_or(Error::Encoding)?;
 
         let mut key_val = unsafe { crate::into_val(&key_bytes) };
         let mut data_val = unsafe { crate::into_val(&data_bytes) };
@@ -1608,15 +1608,15 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn append<'a, T>(&self, txn: &mut RwTxn<T>, key: KC::EItem<'a>, data: DC::EItem<'a>) -> Result<()>
+    pub fn append<'a, 'b, T>(&self, txn: &mut RwTxn<T>, key: &'b KC::EItem<'a>, data: &'b DC::EItem<'a>) -> Result<()>
     where
         KC: BytesEncode,
         DC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).ok_or(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).ok_or(Error::Encoding)?;
 
         let mut key_val = unsafe { crate::into_val(&key_bytes) };
         let mut data_val = unsafe { crate::into_val(&data_bytes) };
@@ -1676,7 +1676,7 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete<'a, T>(&self, txn: &mut RwTxn<T>, key: KC::EItem<'a>) -> Result<bool>
+    pub fn delete<'a, 'b, T>(&self, txn: &mut RwTxn<T>, key: &'b KC::EItem<'a>) -> Result<bool>
     where
         KC: BytesEncode,
     {

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -22,7 +22,7 @@ use crate::types::DecodeIgnore;
 /// # use heed::EnvOpenOptions;
 /// use heed::Database;
 /// use heed::types::*;
-/// use heed::{zerocopy::I64, byteorder::BigEndian};
+/// use heed::byteorder::BigEndian;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -69,7 +69,7 @@ use crate::types::DecodeIgnore;
 /// # use heed::EnvOpenOptions;
 /// use heed::Database;
 /// use heed::types::*;
-/// use heed::{zerocopy::I64, byteorder::BigEndian};
+/// use heed::byteorder::BigEndian;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -265,7 +265,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -333,7 +333,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -405,7 +405,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -476,7 +476,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::U32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -541,7 +541,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -594,7 +594,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -643,7 +643,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -699,7 +699,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -746,7 +746,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -787,7 +787,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -841,7 +841,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -883,7 +883,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -939,7 +939,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1017,7 +1017,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1108,7 +1108,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1186,7 +1186,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1277,7 +1277,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1332,7 +1332,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1400,7 +1400,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1455,7 +1455,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1520,7 +1520,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1583,7 +1583,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1645,7 +1645,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1716,7 +1716,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1780,7 +1780,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;
@@ -1828,7 +1828,7 @@ impl<KC, DC> Database<KC, DC> {
     /// # use heed::EnvOpenOptions;
     /// use heed::Database;
     /// use heed::types::*;
-    /// use heed::{zerocopy::I32, byteorder::BigEndian};
+    /// use heed::byteorder::BigEndian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # fs::create_dir_all(Path::new("target").join("zerocopy.mdb"))?;

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -220,9 +220,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'a, 'txn, T>(&self, txn: &'txn RoTxn<T>, key: &'a KC::EItem) -> Result<Option<DC::DItem>>
+    pub fn get<'a, 'txn, T>(&self, txn: &'txn RoTxn<T>, key: KC::EItem<'a>) -> Result<Option<DC::DItem>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -298,10 +298,10 @@ impl<KC, DC> Database<KC, DC> {
     pub fn get_lower_than<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -366,10 +366,10 @@ impl<KC, DC> Database<KC, DC> {
     pub fn get_lower_than_or_equal_to<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -438,10 +438,10 @@ impl<KC, DC> Database<KC, DC> {
     pub fn get_greater_than<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -509,10 +509,10 @@ impl<KC, DC> Database<KC, DC> {
     pub fn get_greater_than_or_equal_to<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: KC::EItem<'a>,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -971,11 +971,11 @@ impl<KC, DC> Database<KC, DC> {
     pub fn range<'a, 'txn, T, R>(
         &self,
         txn: &'txn RoTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RoRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
-        R: RangeBounds<KC::EItem>,
+        KC: BytesEncode,
+        R: RangeBounds<KC::EItem<'a>>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
 
@@ -1062,11 +1062,11 @@ impl<KC, DC> Database<KC, DC> {
     pub fn range_mut<'a, 'txn, T, R>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RwRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
-        R: RangeBounds<KC::EItem>,
+        KC: BytesEncode,
+        R: RangeBounds<KC::EItem<'a>>,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1140,11 +1140,11 @@ impl<KC, DC> Database<KC, DC> {
     pub fn rev_range<'a, 'txn, T, R>(
         &self,
         txn: &'txn RoTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RoRevRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
-        R: RangeBounds<KC::EItem>,
+        KC: BytesEncode,
+        R: RangeBounds<KC::EItem<'a>>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
 
@@ -1231,11 +1231,11 @@ impl<KC, DC> Database<KC, DC> {
     pub fn rev_range_mut<'a, 'txn, T, R>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RwRevRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
-        R: RangeBounds<KC::EItem>,
+        KC: BytesEncode,
+        R: RangeBounds<KC::EItem<'a>>,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1310,13 +1310,13 @@ impl<KC, DC> Database<KC, DC> {
     pub fn prefix_iter<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: KC::EItem<'a>,
     ) -> Result<RoPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RoCursor::new(txn, self.dbi).map(|cursor| RoPrefix::new(cursor, prefix_bytes))
     }
@@ -1378,13 +1378,13 @@ impl<KC, DC> Database<KC, DC> {
     pub fn prefix_iter_mut<'a, 'txn, T>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: KC::EItem<'a>,
     ) -> Result<RwPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RwCursor::new(txn, self.dbi).map(|cursor| RwPrefix::new(cursor, prefix_bytes))
     }
@@ -1433,13 +1433,13 @@ impl<KC, DC> Database<KC, DC> {
     pub fn rev_prefix_iter<'a, 'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: KC::EItem<'a>,
     ) -> Result<RoRevPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RoCursor::new(txn, self.dbi).map(|cursor| RoRevPrefix::new(cursor, prefix_bytes))
     }
@@ -1501,13 +1501,13 @@ impl<KC, DC> Database<KC, DC> {
     pub fn rev_prefix_iter_mut<'a, 'txn, T>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: KC::EItem<'a>,
     ) -> Result<RwRevPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
-        let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
+        let prefix_bytes = KC::bytes_encode(&prefix).ok_or(Error::Encoding)?;
         let prefix_bytes = prefix_bytes.into_owned();
         RwCursor::new(txn, self.dbi).map(|cursor| RwRevPrefix::new(cursor, prefix_bytes))
     }
@@ -1545,10 +1545,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn put<'a, T>(&self, txn: &mut RwTxn<T>, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn put<'a, T>(&self, txn: &mut RwTxn<T>, key: KC::EItem<'a>, data: DC::EItem<'a>) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1608,10 +1608,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn append<'a, T>(&self, txn: &mut RwTxn<T>, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn append<'a, T>(&self, txn: &mut RwTxn<T>, key: KC::EItem<'a>, data: DC::EItem<'a>) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1676,9 +1676,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete<'a, T>(&self, txn: &mut RwTxn<T>, key: &'a KC::EItem) -> Result<bool>
+    pub fn delete<'a, T>(&self, txn: &mut RwTxn<T>, key: KC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1749,10 +1749,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete_range<'a, 'txn, T, R>(&self, txn: &'txn mut RwTxn<T>, range: &'a R) -> Result<usize>
+    pub fn delete_range<'a, 'txn, T, R>(&self, txn: &'txn mut RwTxn<T>, range: R) -> Result<usize>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
-        R: RangeBounds<KC::EItem>,
+        KC: BytesEncode + BytesDecode<'txn>,
+        R: RangeBounds<KC::EItem<'a>>,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 

--- a/heed/src/iter/iter.rs
+++ b/heed/src/iter/iter.rs
@@ -112,10 +112,10 @@ impl<'txn, KC, DC> RwIter<'txn, KC, DC> {
     ///
     /// This is intended to be used when the new data is the same size as the old.
     /// Otherwise it will simply perform a delete of the old record followed by an insert.
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -126,10 +126,10 @@ impl<'txn, KC, DC> RwIter<'txn, KC, DC> {
     ///
     /// If a key is inserted that is less than any previous key a `KeyExist` error
     /// is returned and the key is not inserted into the database.
-    pub fn append<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn append<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -320,10 +320,10 @@ impl<'txn, KC, DC> RwRevIter<'txn, KC, DC> {
     ///
     /// This is intended to be used when the new data is the same size as the old.
     /// Otherwise it will simply perform a delete of the old record followed by an insert.
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -334,10 +334,10 @@ impl<'txn, KC, DC> RwRevIter<'txn, KC, DC> {
     ///
     /// If a key is inserted that is less than any previous key a `KeyExist` error
     /// is returned and the key is not inserted into the database.
-    pub fn append<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn append<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/heed/src/iter/mod.rs
+++ b/heed/src/iter/mod.rs
@@ -72,10 +72,10 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(2), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(3), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(4), &()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(1), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(2), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(3), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(4), ()).unwrap();
 
         // Lets check that we properly get the last entry.
         let iter = db.iter(&wtxn).unwrap();
@@ -106,7 +106,7 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(1), ()).unwrap();
 
         // Lets check that we properly get the last entry.
         let iter = db.iter(&wtxn).unwrap();
@@ -137,29 +137,29 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(2), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(3), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(4), &()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(1), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(2), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(3), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(4), ()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.range(&wtxn, &(..)).unwrap();
+        let iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(4), ())));
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(4), ())));
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(4), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
@@ -168,40 +168,40 @@ mod tests {
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let range = BEI32::new(2)..=BEI32::new(4);
-        let mut iter = db.range(&wtxn, &range).unwrap();
+        let mut iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(4), ())));
 
         let range = BEI32::new(2)..BEI32::new(4);
-        let mut iter = db.range(&wtxn, &range).unwrap();
+        let mut iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(3), ())));
 
         let range = BEI32::new(2)..BEI32::new(4);
-        let mut iter = db.range(&wtxn, &range).unwrap();
+        let mut iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let range = BEI32::new(2)..BEI32::new(2);
-        let iter = db.range(&wtxn, &range).unwrap();
+        let iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let range = BEI32::new(2)..=BEI32::new(1);
-        let iter = db.range(&wtxn, &range).unwrap();
+        let iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         wtxn.abort().unwrap();
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(1), ()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.range(&wtxn, &(..)).unwrap();
+        let iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
@@ -224,10 +224,10 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], ()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], ()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], ()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], ()).unwrap();
 
         // Lets check that we properly get the last entry.
         let iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
@@ -270,10 +270,10 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], ()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], ()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], ()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], ()).unwrap();
 
         // Lets check that we properly get the last entry.
         let iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
@@ -318,31 +318,31 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(2), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(3), &()).unwrap();
-        db.put(&mut wtxn, &BEI32::new(4), &()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(1), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(2), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(3), ()).unwrap();
+        db.put(&mut wtxn, &BEI32::new(4), ()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.rev_range(&wtxn, &(BEI32::new(1)..=BEI32::new(3))).unwrap();
+        let iter = db.rev_range(&wtxn, BEI32::new(1)..=BEI32::new(3)).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.rev_range(&wtxn, &(BEI32::new(0)..BEI32::new(4))).unwrap();
+        let mut iter = db.rev_range(&wtxn, BEI32::new(0)..BEI32::new(4)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.rev_range(&wtxn, &(BEI32::new(0)..=BEI32::new(5))).unwrap();
+        let mut iter = db.rev_range(&wtxn, BEI32::new(0)..=BEI32::new(5)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(4), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
-        let iter = db.rev_range(&wtxn, &(BEI32::new(0)..=BEI32::new(5))).unwrap();
+        let iter = db.rev_range(&wtxn, BEI32::new(0)..=BEI32::new(5)).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.rev_range(&wtxn, &(BEI32::new(4)..=BEI32::new(4))).unwrap();
+        let mut iter = db.rev_range(&wtxn, BEI32::new(4)..=BEI32::new(4)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(4), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 

--- a/heed/src/iter/mod.rs
+++ b/heed/src/iter/mod.rs
@@ -59,8 +59,8 @@ mod tests {
         use std::fs;
         use std::path::Path;
         use crate::EnvOpenOptions;
+        use crate::byteorder::BigEndian;
         use crate::types::*;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
 
         fs::create_dir_all(Path::new("target").join("iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
@@ -124,7 +124,7 @@ mod tests {
         use std::fs;
         use std::path::Path;
         use crate::EnvOpenOptions;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+        use crate::byteorder::BigEndian;
         use crate::types::*;
 
         fs::create_dir_all(Path::new("target").join("iter_last.mdb")).unwrap();
@@ -305,7 +305,7 @@ mod tests {
         use std::fs;
         use std::path::Path;
         use crate::EnvOpenOptions;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+        use crate::byteorder::BigEndian;
         use crate::types::*;
 
         fs::create_dir_all(Path::new("target").join("range_iter_last.mdb")).unwrap();

--- a/heed/src/iter/prefix.rs
+++ b/heed/src/iter/prefix.rs
@@ -132,13 +132,13 @@ impl<'txn, KC, DC> RwPrefix<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).ok_or(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).ok_or(Error::Encoding)?;
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
@@ -346,10 +346,10 @@ impl<'txn, KC, DC> RwRevPrefix<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/heed/src/iter/range.rs
+++ b/heed/src/iter/range.rs
@@ -198,10 +198,10 @@ impl<'txn, KC, DC> RwRange<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -462,10 +462,10 @@ impl<'txn, KC, DC> RwRevRange<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current<'a>(&mut self, key: &'a KC::EItem<'a>, data: &'a DC::EItem<'a>) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 //! Crate `heed` is a high-level wrapper of [LMDB], high-level doesn't mean heavy (think about Rust).
 //!
 //! It provides you a way to store types in LMDB without any limit and with a minimal overhead as possible,

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -55,9 +55,9 @@ mod lazy_decode;
 mod mdb;
 mod txn;
 
+pub use bytemuck;
 pub use byteorder;
 pub use heed_types as types;
-pub use zerocopy;
 use heed_traits as traits;
 
 pub use self::database::Database;


### PR DESCRIPTION
This depends on [the `generic_associated_types` Rust feature](https://github.com/rust-lang/rust/issues/44265).

I am just not sure if I can make the `Database::rev_/range/_mut` range argument better. I doubt the `BytesEncoding` trait, especially the `OwnedType`, `CowType`, and `UnalignedType` `EItem`s.