### PR TITLE
Better stable bytes encode trait

### DIFF
--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-pub trait BytesEncode<'a> {
-    type EItem: ?Sized + 'a;
+pub trait BytesEncode {
+    type EItem: ?Sized;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<'a, [u8]>>;
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>>;
 }
 
 pub trait BytesDecode<'a> {

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -18,17 +18,17 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// [`Cow`]: std::borrow::Cow
 /// [`UnalignedSlice`]: crate::UnalignedSlice
 /// [`OwnedSlice`]: crate::OwnedSlice
-pub struct CowSlice<T>(std::marker::PhantomData<T>);
+pub struct CowSlice<'a, T>(std::marker::PhantomData<&'a T>);
 
-impl<'a, T: Pod> BytesEncode<'a> for CowSlice<T> {
-    type EItem = [T];
+impl<'a, T: Pod> BytesEncode for CowSlice<'a, T> {
+    type EItem = &'a [T];
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a, T: Pod> BytesDecode<'a> for CowSlice<T> {
+impl<'a, T: Pod> BytesDecode<'a> for CowSlice<'_, T> {
     type DItem = Cow<'a, [T]>;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
@@ -40,6 +40,6 @@ impl<'a, T: Pod> BytesDecode<'a> for CowSlice<T> {
     }
 }
 
-unsafe impl<T> Send for CowSlice<T> {}
+unsafe impl<T> Send for CowSlice<'_, T> {}
 
-unsafe impl<T> Sync for CowSlice<T> {}
+unsafe impl<T> Sync for CowSlice<'_, T> {}

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -26,10 +26,10 @@ use bytemuck::{Pod, PodCastError, bytes_of, bytes_of_mut, try_from_bytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct CowType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod> BytesEncode<'a> for CowType<T> {
+impl<T: Pod> BytesEncode for CowType<T> {
     type EItem = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(bytes_of(item)))
     }
 }

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -4,7 +4,7 @@
 //! For specific types you can choose:
 //!   - [`Str`] to store [`str`](primitive@str)s
 //!   - [`Unit`] to store `()` types
-//!   - [`SerdeBincode`] or [`SerdeJson`] to store [`Serialize`]/[`Deserialize`] types
+//!   - [`SerdeBincode`] or [`SerdeJson`] to store [`serde::Serialize`]/[`serde::Deserialize`] types
 //!
 //! But if you want to store big types that can be efficiently deserialized then
 //! here is a little table to help you in your quest:

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -51,7 +51,7 @@ pub use self::unit::Unit;
 /// borrowed and doesn't depends on any [memory alignment].
 ///
 /// [memory alignment]: std::mem::align_of()
-pub type ByteSlice = UnalignedSlice<u8>;
+pub type ByteSlice<'a> = UnalignedSlice<'a, u8>;
 
 /// A convenient struct made to ignore the type when decoding it.
 ///

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -18,17 +18,17 @@ use crate::CowSlice;
 /// [memory alignment]: std::mem::align_of()
 /// [`UnalignedSlice`]: crate::UnalignedSlice
 /// [`CowType`]: crate::CowType
-pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
+pub struct OwnedSlice<'a, T>(std::marker::PhantomData<&'a T>);
 
-impl<'a, T: Pod> BytesEncode<'a> for OwnedSlice<T> {
-    type EItem = [T];
+impl<'a, T: Pod> BytesEncode for OwnedSlice<'a, T> {
+    type EItem = &'a [T];
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         CowSlice::bytes_encode(item)
     }
 }
 
-impl<'a, T: Pod> BytesDecode<'a> for OwnedSlice<T> {
+impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedSlice<'_, T> {
     type DItem = Vec<T>;
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {
@@ -36,6 +36,6 @@ impl<'a, T: Pod> BytesDecode<'a> for OwnedSlice<T> {
     }
 }
 
-unsafe impl<T> Send for OwnedSlice<T> {}
+unsafe impl<T> Send for OwnedSlice<'_, T> {}
 
-unsafe impl<T> Sync for OwnedSlice<T> {}
+unsafe impl<T> Sync for OwnedSlice<'_, T> {}

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -26,10 +26,10 @@ use crate::CowType;
 /// [`CowSlice`]: crate::CowSlice
 pub struct OwnedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod> BytesEncode<'a> for OwnedType<T> {
+impl<T: Pod> BytesEncode for OwnedType<T> {
     type EItem = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         CowType::bytes_encode(item)
     }
 }

--- a/heed-types/src/serde_bincode.rs
+++ b/heed-types/src/serde_bincode.rs
@@ -7,13 +7,13 @@ use std::borrow::Cow;
 /// It can borrow bytes from the original slice.
 pub struct SerdeBincode<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for SerdeBincode<T>
+impl<T> BytesEncode for SerdeBincode<T>
 where
     T: Serialize,
 {
     type EItem = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         bincode::serialize(item).map(Cow::Owned).ok()
     }
 }

--- a/heed-types/src/serde_json.rs
+++ b/heed-types/src/serde_json.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 /// It can borrow bytes from the original slice.
 pub struct SerdeJson<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: 'a> BytesEncode<'a> for SerdeJson<T>
+impl<T> BytesEncode for SerdeJson<T>
 where
     T: Serialize,
 {

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -4,7 +4,7 @@ use std::{str, marker};
 use heed_traits::{BytesDecode, BytesEncode};
 use bytemuck::try_cast_slice;
 
-/// Describes an [`str`].
+/// Describes an [`prim@str`].
 pub struct Str<'a> {
     _phantom: marker::PhantomData<&'a ()>,
 }

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -1,22 +1,23 @@
 use std::borrow::Cow;
-use std::str;
+use std::{str, marker};
 
 use heed_traits::{BytesDecode, BytesEncode};
+use bytemuck::try_cast_slice;
 
-use crate::UnalignedSlice;
+/// Describes an [`str`].
+pub struct Str<'a> {
+    _phantom: marker::PhantomData<&'a ()>,
+}
 
-/// Describes an [`prim@str`].
-pub struct Str;
-
-impl BytesEncode<'_> for Str {
-    type EItem = str;
+impl<'a> BytesEncode for Str<'a> {
+    type EItem = &'a str;
 
     fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
-        UnalignedSlice::<u8>::bytes_encode(item.as_bytes())
+        try_cast_slice(item.as_bytes()).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a> BytesDecode<'a> for Str {
+impl<'a> BytesDecode<'a> for Str<'_> {
     type DItem = &'a str;
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -11,17 +11,17 @@ use bytemuck::{Pod, try_cast_slice};
 ///
 /// [memory alignment]: std::mem::align_of()
 /// [`CowType`]: crate::CowType
-pub struct UnalignedSlice<T>(std::marker::PhantomData<T>);
+pub struct UnalignedSlice<'a, T>(std::marker::PhantomData<&'a T>);
 
-impl<'a, T: Pod> BytesEncode<'a> for UnalignedSlice<T> {
-    type EItem = [T];
+impl<'a, T: Pod> BytesEncode for UnalignedSlice<'a, T> {
+    type EItem = &'a [T];
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         try_cast_slice(item).map(Cow::Borrowed).ok()
     }
 }
 
-impl<'a, T: Pod> BytesDecode<'a> for UnalignedSlice<T> {
+impl<'a, T: Pod> BytesDecode<'a> for UnalignedSlice<'_, T> {
     type DItem = &'a [T];
 
     fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
@@ -29,6 +29,6 @@ impl<'a, T: Pod> BytesDecode<'a> for UnalignedSlice<T> {
     }
 }
 
-unsafe impl<T> Send for UnalignedSlice<T> {}
+unsafe impl<T> Send for UnalignedSlice<'_, T> {}
 
-unsafe impl<T> Sync for UnalignedSlice<T> {}
+unsafe impl<T> Sync for UnalignedSlice<'_, T> {}

--- a/heed-types/src/unaligned_type.rs
+++ b/heed-types/src/unaligned_type.rs
@@ -19,10 +19,10 @@ use bytemuck::{Pod, bytes_of, try_from_bytes};
 /// [`CowSlice`]: crate::CowSlice
 pub struct UnalignedType<T>(std::marker::PhantomData<T>);
 
-impl<'a, T: Pod> BytesEncode<'a> for UnalignedType<T> {
+impl<T: Pod> BytesEncode for UnalignedType<T> {
     type EItem = T;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Option<Cow<[u8]>> {
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
         Some(Cow::Borrowed(bytes_of(item)))
     }
 }

--- a/heed-types/src/unit.rs
+++ b/heed-types/src/unit.rs
@@ -4,7 +4,7 @@ use heed_traits::{BytesDecode, BytesEncode};
 /// Describes the `()` type.
 pub struct Unit;
 
-impl BytesEncode<'_> for Unit {
+impl BytesEncode for Unit {
     type EItem = ();
 
     fn bytes_encode(_item: &Self::EItem) -> Option<Cow<[u8]>> {

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<OwnedType<[i32; 2]>, Str> = env.create_database(Some("kikou"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, &[2, 3], "what's up?")?;
+    let _ret = db.put(&mut wtxn, &[2, 3], &"what's up?")?;
     let ret: Option<&str> = db.get(&wtxn, &[2, 3])?;
 
     println!("{:?}", ret);
@@ -35,8 +35,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<Str, ByteSlice> = env.create_database(Some("kiki"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, "hello", &[2, 3][..])?;
-    let ret: Option<&[u8]> = db.get(&wtxn, "hello")?;
+    let _ret = db.put(&mut wtxn, &"hello", &&[2, 3][..])?;
+    let ret: Option<&[u8]> = db.get(&wtxn, &"hello")?;
 
     println!("{:?}", ret);
     wtxn.commit()?;
@@ -52,9 +52,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let hello = Hello { string: "hi" };
-    db.put(&mut wtxn, "hello", &hello)?;
+    db.put(&mut wtxn, &"hello", &hello)?;
 
-    let ret: Option<Hello> = db.get(&wtxn, "hello")?;
+    let ret: Option<Hello> = db.get(&wtxn, &"hello")?;
     println!("serde-bincode:\t{:?}", ret);
 
     wtxn.commit()?;
@@ -64,9 +64,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let hello = Hello { string: "hi" };
-    db.put(&mut wtxn, "hello", &hello)?;
+    db.put(&mut wtxn, &"hello", &hello)?;
 
-    let ret: Option<Hello> = db.get(&wtxn, "hello")?;
+    let ret: Option<Hello> = db.get(&wtxn, &"hello")?;
     println!("serde-json:\t{:?}", ret);
 
     wtxn.commit()?;
@@ -84,9 +84,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     let zerobytes = ZeroBytes { bytes: [24; 12] };
-    db.put(&mut wtxn, "zero", &zerobytes)?;
+    db.put(&mut wtxn, &"zero", &zerobytes)?;
 
-    let ret = db.get(&wtxn, "zero")?;
+    let ret = db.get(&wtxn, &"zero")?;
 
     println!("{:?}", ret);
     wtxn.commit()?;
@@ -95,12 +95,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db: Database<Str, Unit> = env.create_database(Some("ignored-data"))?;
 
     let mut wtxn = env.write_txn()?;
-    let _ret = db.put(&mut wtxn, "hello", &())?;
-    let ret: Option<()> = db.get(&wtxn, "hello")?;
+    let _ret = db.put(&mut wtxn, &"hello", &())?;
+    let ret: Option<()> = db.get(&wtxn, &"hello")?;
 
     println!("{:?}", ret);
 
-    let ret: Option<()> = db.get(&wtxn, "non-existant")?;
+    let ret: Option<()> = db.get(&wtxn, &"non-existant")?;
 
     println!("{:?}", ret);
     wtxn.commit()?;
@@ -136,18 +136,33 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // or iterate over ranges too!!!
     let range = BEI64::new(35)..=BEI64::new(42);
-    let rets: Result<Vec<(BEI64, _)>, _> = db.range(&wtxn, &range)?.collect();
+    let rets: Result<Vec<(BEI64, _)>, _> = db.range(&wtxn, range)?.collect();
 
     println!("{:?}", rets);
 
     // delete a range of key
     let range = BEI64::new(35)..=BEI64::new(42);
-    let deleted: usize = db.delete_range(&mut wtxn, &range)?;
+    let deleted: usize = db.delete_range(&mut wtxn, range)?;
 
     let rets: Result<Vec<(BEI64, _)>, _> = db.iter(&wtxn)?.collect();
 
     println!("deleted: {:?}, {:?}", deleted, rets);
     wtxn.commit()?;
+
+    // We also try to create a range for of str
+    let db: Database<Str, Unit> = env.create_database(Some("str-range"))?;
+
+    let mut wtxn = env.write_txn()?;
+    let _ret = db.put(&mut wtxn, &"a", &())?;
+    let _ret = db.put(&mut wtxn, &"b", &())?;
+    let _ret = db.put(&mut wtxn, &"c", &())?;
+    let _ret = db.put(&mut wtxn, &"d", &())?;
+
+    // or iterate over ranges too!!!
+    let range = "a"..="f";
+    let rets: Result<Vec<(&str, _)>, _> = db.range(&wtxn, range)?.collect();
+
+    println!("{:?}", rets);
 
     Ok(())
 }

--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -164,5 +164,20 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("{:?}", rets);
 
+    // We also try to create a range for of str
+    let db: Database<ByteSlice, Unit> = env.create_database(Some("bytes-range"))?;
+
+    let mut wtxn = env.write_txn()?;
+    let _ret = db.put(&mut wtxn, &&[1][..], &())?;
+    let _ret = db.put(&mut wtxn, &&[2][..], &())?;
+    let _ret = db.put(&mut wtxn, &&[3][..], &())?;
+    let _ret = db.put(&mut wtxn, &&[4][..], &())?;
+
+    // or iterate over ranges too!!!
+    let range = &[1][..]..=&[10][..];
+    let rets: Result<Vec<(&[u8], _)>, _> = db.range(&wtxn, range)?.collect();
+
+    println!("{:?}", rets);
+
     Ok(())
 }

--- a/heed/examples/clear-database.rs
+++ b/heed/examples/clear-database.rs
@@ -22,14 +22,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     // We fill the db database with entries.
-    db.put(&mut wtxn, "I am here", "to test things")?;
-    db.put(&mut wtxn, "I am here too", "for the same purpose")?;
+    db.put(&mut wtxn, &"I am here", &"to test things")?;
+    db.put(&mut wtxn, &"I am here too", &"for the same purpose")?;
 
     wtxn.commit()?;
 
     let mut wtxn = env.write_txn()?;
     db.clear(&mut wtxn)?;
-    db.put(&mut wtxn, "And I come back", "to test things")?;
+    db.put(&mut wtxn, &"And I come back", &"to test things")?;
 
     let mut iter = db.iter(&wtxn)?;
     assert_eq!(iter.next().transpose()?, Some(("And I come back", "to test things")));

--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -24,15 +24,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
 
     // We fill the first database with entries.
-    first.put(&mut wtxn, "I am here", "to test things")?;
-    first.put(&mut wtxn, "I am here too", "for the same purpose")?;
+    first.put(&mut wtxn, &"I am here", &"to test things")?;
+    first.put(&mut wtxn, &"I am here too", &"for the same purpose")?;
 
     // We try to append ordered entries in the second database.
     let mut iter = second.iter_mut(&mut wtxn)?;
 
-    iter.append("aaaa", "lol")?;
-    iter.append("abcd", "lol")?;
-    iter.append("bcde", "lol")?;
+    iter.append(&"aaaa", &"lol")?;
+    iter.append(&"abcd", &"lol")?;
+    iter.append(&"bcde", &"lol")?;
 
     drop(iter);
 

--- a/heed/examples/multi-env.rs
+++ b/heed/examples/multi-env.rs
@@ -38,8 +38,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut wtxn1 = env1.write_txn()?;
 
-    db1.put(&mut wtxn1, "what", &[4, 5][..])?;
-    db1.get(&wtxn1, "what")?;
+    db1.put(&mut wtxn1, &"what", &&[4, 5][..])?;
+    db1.get(&wtxn1, &"what")?;
     wtxn1.commit()?;
 
     let rtxn2 = env2.read_txn()?;

--- a/heed/examples/nested.rs
+++ b/heed/examples/nested.rs
@@ -29,14 +29,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut nwtxn = env.nested_write_txn(&mut wtxn)?;
 
-    db.put(&mut nwtxn, "what", &[4, 5][..])?;
-    let ret = db.get(&nwtxn, "what")?;
+    db.put(&mut nwtxn, &"what", &&[4, 5][..])?;
+    let ret = db.get(&nwtxn, &"what")?;
     println!("nested(1) \"what\": {:?}", ret);
 
     println!("nested(1) abort");
     nwtxn.abort()?;
 
-    let ret = db.get(&wtxn, "what")?;
+    let ret = db.get(&wtxn, &"what")?;
     println!("parent \"what\": {:?}", ret);
 
     // ------
@@ -46,20 +46,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut nwtxn = env.nested_write_txn(&mut wtxn)?;
     let mut nnwtxn = env.nested_write_txn(&mut nwtxn)?;
 
-    db.put(&mut nnwtxn, "humm...", &[6, 7][..])?;
-    let ret = db.get(&nnwtxn, "humm...")?;
+    db.put(&mut nnwtxn, &"humm...", &&[6, 7][..])?;
+    let ret = db.get(&nnwtxn, &"humm...")?;
     println!("nested(2) \"humm...\": {:?}", ret);
 
     println!("nested(2) commit");
     nnwtxn.commit()?;
     nwtxn.commit()?;
 
-    let ret = db.get(&wtxn, "humm...")?;
+    let ret = db.get(&wtxn, &"humm...")?;
     println!("parent \"humm...\": {:?}", ret);
 
-    db.put(&mut wtxn, "hello", &[2, 3][..])?;
+    db.put(&mut wtxn, &"hello", &&[2, 3][..])?;
 
-    let ret = db.get(&wtxn, "hello")?;
+    let ret = db.get(&wtxn, &"hello")?;
     println!("parent \"hello\": {:?}", ret);
 
     println!("parent commit");
@@ -70,10 +70,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let rtxn = env.read_txn()?;
 
-    let ret = db.get(&rtxn, "hello")?;
+    let ret = db.get(&rtxn, &"hello")?;
     println!("parent (reader) \"hello\": {:?}", ret);
 
-    let ret = db.get(&rtxn, "humm...")?;
+    let ret = db.get(&rtxn, &"humm...")?;
     println!("parent (reader) \"humm...\": {:?}", ret);
 
     Ok(())

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -90,7 +90,7 @@ use crate::types::DecodeIgnore;
 ///
 /// // you can iterate over ranges too!!!
 /// let range = BEI64::new(35)..=BEI64::new(42);
-/// let rets: Result<_, _> = db.range(&wtxn, &range)?.collect();
+/// let rets: Result<_, _> = db.range(&wtxn, range)?.collect();
 /// let rets: Vec<(BEI64, _)> = rets?;
 ///
 /// let expected = vec![
@@ -102,7 +102,7 @@ use crate::types::DecodeIgnore;
 ///
 /// // even delete a range of keys
 /// let range = BEI64::new(35)..=BEI64::new(42);
-/// let deleted: usize = db.delete_range(&mut wtxn, &range)?;
+/// let deleted: usize = db.delete_range(&mut wtxn, range)?;
 ///
 /// let rets: Result<_, _> = db.iter(&wtxn)?.collect();
 /// let rets: Vec<(BEI64, _)> = rets?;
@@ -208,21 +208,21 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, "i-am-forty-two", &42)?;
-    /// db.put(&mut wtxn, "i-am-twenty-seven", &27)?;
+    /// db.put(&mut wtxn, &"i-am-forty-two", &42)?;
+    /// db.put(&mut wtxn, &"i-am-twenty-seven", &27)?;
     ///
-    /// let ret = db.get(&wtxn, "i-am-forty-two")?;
+    /// let ret = db.get(&wtxn, &"i-am-forty-two")?;
     /// assert_eq!(ret, Some(42));
     ///
-    /// let ret = db.get(&wtxn, "i-am-twenty-one")?;
+    /// let ret = db.get(&wtxn, &"i-am-twenty-one")?;
     /// assert_eq!(ret, None);
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'a, 'txn, T>(&self, txn: &'txn RoTxn<T>, key: &'a KC::EItem) -> Result<Option<DC::DItem>>
+    pub fn get<'txn, T>(&self, txn: &'txn RoTxn<T>, key: &KC::EItem) -> Result<Option<DC::DItem>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -295,13 +295,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than<'a, 'txn, T>(
+    pub fn get_lower_than<'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: &KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -363,13 +363,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_lower_than_or_equal_to<'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: &KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -435,13 +435,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than<'a, 'txn, T>(
+    pub fn get_greater_than<'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: &KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -506,13 +506,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_greater_than_or_equal_to<'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
+        key: &KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -555,8 +555,8 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
     ///
     /// let ret = db.first(&wtxn)?;
     /// assert_eq!(ret, Some((BEI32::new(27), "i-am-twenty-seven")));
@@ -608,8 +608,8 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
     ///
     /// let ret = db.last(&wtxn)?;
     /// assert_eq!(ret, Some((BEI32::new(42), "i-am-forty-two")));
@@ -657,10 +657,10 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let ret = db.len(&wtxn)?;
     /// assert_eq!(ret, 4);
@@ -713,10 +713,10 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let ret = db.is_empty(&wtxn)?;
     /// assert_eq!(ret, false);
@@ -760,9 +760,9 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
     ///
     /// let mut iter = db.iter(&wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(13), "i-am-thirteen")));
@@ -801,9 +801,9 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
     ///
     /// let mut iter = db.iter_mut(&mut wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(13), "i-am-thirteen")));
@@ -812,7 +812,7 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
-    /// let ret = iter.put_current(&BEI32::new(42), "i-am-the-new-forty-two")?;
+    /// let ret = iter.put_current(&BEI32::new(42), &"i-am-the-new-forty-two")?;
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
@@ -855,9 +855,9 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
     ///
     /// let mut iter = db.rev_iter(&wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
@@ -897,9 +897,9 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
     ///
     /// let mut iter = db.rev_iter_mut(&mut wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
@@ -908,7 +908,7 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(13), "i-am-thirteen")));
-    /// let ret = iter.put_current(&BEI32::new(13), "i-am-the-new-thirteen")?;
+    /// let ret = iter.put_current(&BEI32::new(13), &"i-am-the-new-thirteen")?;
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
@@ -953,13 +953,13 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let mut iter = db.range(&wtxn, &range)?;
+    /// let mut iter = db.range(&wtxn, range)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
     /// assert_eq!(iter.next().transpose()?, None);
@@ -968,13 +968,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range<'a, 'txn, T, R>(
+    pub fn range<'txn, T, R>(
         &self,
         txn: &'txn RoTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RoRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
         R: RangeBounds<KC::EItem>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -1031,18 +1031,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let mut range = db.range_mut(&mut wtxn, &range)?;
+    /// let mut range = db.range_mut(&mut wtxn, range)?;
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// let ret = range.del_current()?;
     /// assert!(ret);
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
-    /// let ret = range.put_current(&BEI32::new(42), "i-am-the-new-forty-two")?;
+    /// let ret = range.put_current(&BEI32::new(42), &"i-am-the-new-forty-two")?;
     /// assert!(ret);
     ///
     /// assert_eq!(range.next().transpose()?, None);
@@ -1059,13 +1059,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range_mut<'a, 'txn, T, R>(
+    pub fn range_mut<'txn, T, R>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RwRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
         R: RangeBounds<KC::EItem>,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
@@ -1122,13 +1122,13 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(43);
-    /// let mut iter = db.rev_range(&wtxn, &range)?;
+    /// let mut iter = db.rev_range(&wtxn, range)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, None);
@@ -1137,13 +1137,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_range<'a, 'txn, T, R>(
+    pub fn rev_range<'txn, T, R>(
         &self,
         txn: &'txn RoTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RoRevRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
         R: RangeBounds<KC::EItem>,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
@@ -1200,18 +1200,18 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let mut range = db.rev_range_mut(&mut wtxn, &range)?;
+    /// let mut range = db.rev_range_mut(&mut wtxn, range)?;
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
     /// let ret = range.del_current()?;
     /// assert!(ret);
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
-    /// let ret = range.put_current(&BEI32::new(27), "i-am-the-new-twenty-seven")?;
+    /// let ret = range.put_current(&BEI32::new(27), &"i-am-the-new-twenty-seven")?;
     /// assert!(ret);
     ///
     /// assert_eq!(range.next().transpose()?, None);
@@ -1228,13 +1228,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_range_mut<'a, 'txn, T, R>(
+    pub fn rev_range_mut<'txn, T, R>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        range: &'a R,
+        range: R,
     ) -> Result<RwRevRange<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
         R: RangeBounds<KC::EItem>,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
@@ -1291,13 +1291,13 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
-    /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
-    /// db.put(&mut wtxn, "i-am-twenty-nine",  &BEI32::new(29))?;
-    /// db.put(&mut wtxn, "i-am-forty-one",    &BEI32::new(41))?;
-    /// db.put(&mut wtxn, "i-am-forty-two",    &BEI32::new(42))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-eight", &BEI32::new(28))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-seven", &BEI32::new(27))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-nine",  &BEI32::new(29))?;
+    /// db.put(&mut wtxn, &"i-am-forty-one",    &BEI32::new(41))?;
+    /// db.put(&mut wtxn, &"i-am-forty-two",    &BEI32::new(42))?;
     ///
-    /// let mut iter = db.prefix_iter(&mut wtxn, "i-am-twenty")?;
+    /// let mut iter = db.prefix_iter(&mut wtxn, &"i-am-twenty")?;
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-eight", BEI32::new(28))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-nine", BEI32::new(29))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-seven", BEI32::new(27))));
@@ -1307,13 +1307,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter<'a, 'txn, T>(
+    pub fn prefix_iter<'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: &KC::EItem,
     ) -> Result<RoPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
         let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
@@ -1346,42 +1346,42 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
-    /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
-    /// db.put(&mut wtxn, "i-am-twenty-nine",  &BEI32::new(29))?;
-    /// db.put(&mut wtxn, "i-am-forty-one",    &BEI32::new(41))?;
-    /// db.put(&mut wtxn, "i-am-forty-two",    &BEI32::new(42))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-eight", &BEI32::new(28))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-seven", &BEI32::new(27))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-nine",  &BEI32::new(29))?;
+    /// db.put(&mut wtxn, &"i-am-forty-one",    &BEI32::new(41))?;
+    /// db.put(&mut wtxn, &"i-am-forty-two",    &BEI32::new(42))?;
     ///
-    /// let mut iter = db.prefix_iter_mut(&mut wtxn, "i-am-twenty")?;
+    /// let mut iter = db.prefix_iter_mut(&mut wtxn, &"i-am-twenty")?;
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-eight", BEI32::new(28))));
     /// let ret = iter.del_current()?;
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-nine", BEI32::new(29))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-seven", BEI32::new(27))));
-    /// let ret = iter.put_current("i-am-twenty-seven", &BEI32::new(27000))?;
+    /// let ret = iter.put_current(&"i-am-twenty-seven", &BEI32::new(27000))?;
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
     ///
     /// drop(iter);
     ///
-    /// let ret = db.get(&wtxn, "i-am-twenty-eight")?;
+    /// let ret = db.get(&wtxn, &"i-am-twenty-eight")?;
     /// assert_eq!(ret, None);
     ///
-    /// let ret = db.get(&wtxn, "i-am-twenty-seven")?;
+    /// let ret = db.get(&wtxn, &"i-am-twenty-seven")?;
     /// assert_eq!(ret, Some(BEI32::new(27000)));
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter_mut<'a, 'txn, T>(
+    pub fn prefix_iter_mut<'txn, T>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: &KC::EItem,
     ) -> Result<RwPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
         let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
@@ -1414,13 +1414,13 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
-    /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
-    /// db.put(&mut wtxn, "i-am-twenty-nine",  &BEI32::new(29))?;
-    /// db.put(&mut wtxn, "i-am-forty-one",    &BEI32::new(41))?;
-    /// db.put(&mut wtxn, "i-am-forty-two",    &BEI32::new(42))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-eight", &BEI32::new(28))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-seven", &BEI32::new(27))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-nine",  &BEI32::new(29))?;
+    /// db.put(&mut wtxn, &"i-am-forty-one",    &BEI32::new(41))?;
+    /// db.put(&mut wtxn, &"i-am-forty-two",    &BEI32::new(42))?;
     ///
-    /// let mut iter = db.rev_prefix_iter(&mut wtxn, "i-am-twenty")?;
+    /// let mut iter = db.rev_prefix_iter(&mut wtxn, &"i-am-twenty")?;
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-seven", BEI32::new(27))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-nine", BEI32::new(29))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-eight", BEI32::new(28))));
@@ -1430,13 +1430,13 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_prefix_iter<'a, 'txn, T>(
+    pub fn rev_prefix_iter<'txn, T>(
         &self,
         txn: &'txn RoTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: &KC::EItem,
     ) -> Result<RoRevPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.env.env_mut_ptr() as usize);
         let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
@@ -1469,42 +1469,42 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
-    /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
-    /// db.put(&mut wtxn, "i-am-twenty-nine",  &BEI32::new(29))?;
-    /// db.put(&mut wtxn, "i-am-forty-one",    &BEI32::new(41))?;
-    /// db.put(&mut wtxn, "i-am-forty-two",    &BEI32::new(42))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-eight", &BEI32::new(28))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-seven", &BEI32::new(27))?;
+    /// db.put(&mut wtxn, &"i-am-twenty-nine",  &BEI32::new(29))?;
+    /// db.put(&mut wtxn, &"i-am-forty-one",    &BEI32::new(41))?;
+    /// db.put(&mut wtxn, &"i-am-forty-two",    &BEI32::new(42))?;
     ///
-    /// let mut iter = db.rev_prefix_iter_mut(&mut wtxn, "i-am-twenty")?;
+    /// let mut iter = db.rev_prefix_iter_mut(&mut wtxn, &"i-am-twenty")?;
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-seven", BEI32::new(27))));
     /// let ret = iter.del_current()?;
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-nine", BEI32::new(29))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-eight", BEI32::new(28))));
-    /// let ret = iter.put_current("i-am-twenty-eight", &BEI32::new(28000))?;
+    /// let ret = iter.put_current(&"i-am-twenty-eight", &BEI32::new(28000))?;
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
     ///
     /// drop(iter);
     ///
-    /// let ret = db.get(&wtxn, "i-am-twenty-seven")?;
+    /// let ret = db.get(&wtxn, &"i-am-twenty-seven")?;
     /// assert_eq!(ret, None);
     ///
-    /// let ret = db.get(&wtxn, "i-am-twenty-eight")?;
+    /// let ret = db.get(&wtxn, &"i-am-twenty-eight")?;
     /// assert_eq!(ret, Some(BEI32::new(28000)));
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_prefix_iter_mut<'a, 'txn, T>(
+    pub fn rev_prefix_iter_mut<'txn, T>(
         &self,
         txn: &'txn mut RwTxn<T>,
-        prefix: &'a KC::EItem,
+        prefix: &KC::EItem,
     ) -> Result<RwRevPrefix<'txn, KC, DC>>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
         let prefix_bytes = KC::bytes_encode(prefix).ok_or(Error::Encoding)?;
@@ -1534,10 +1534,10 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let ret = db.get(&mut wtxn, &BEI32::new(27))?;
     /// assert_eq!(ret, Some("i-am-twenty-seven"));
@@ -1545,10 +1545,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn put<'a, T>(&self, txn: &mut RwTxn<T>, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn put<T>(&self, txn: &mut RwTxn<T>, key: &KC::EItem, data: &DC::EItem) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1597,10 +1597,10 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let ret = db.get(&mut wtxn, &BEI32::new(27))?;
     /// assert_eq!(ret, Some("i-am-twenty-seven"));
@@ -1608,10 +1608,10 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn append<'a, T>(&self, txn: &mut RwTxn<T>, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn append<T>(&self, txn: &mut RwTxn<T>, key: &KC::EItem, data: &DC::EItem) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1659,10 +1659,10 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let ret = db.delete(&mut wtxn, &BEI32::new(27))?;
     /// assert_eq!(ret, true);
@@ -1676,9 +1676,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete<'a, T>(&self, txn: &mut RwTxn<T>, key: &'a KC::EItem) -> Result<bool>
+    pub fn delete<T>(&self, txn: &mut RwTxn<T>, key: &KC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
+        KC: BytesEncode,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
 
@@ -1730,13 +1730,13 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// let range = BEI32::new(27)..=BEI32::new(42);
-    /// let ret = db.delete_range(&mut wtxn, &range)?;
+    /// let ret = db.delete_range(&mut wtxn, range)?;
     /// assert_eq!(ret, 2);
     ///
     ///
@@ -1749,9 +1749,9 @@ impl<KC, DC> Database<KC, DC> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn delete_range<'a, 'txn, T, R>(&self, txn: &'txn mut RwTxn<T>, range: &'a R) -> Result<usize>
+    pub fn delete_range<'txn, T, R>(&self, txn: &'txn mut RwTxn<T>, range: R) -> Result<usize>
     where
-        KC: BytesEncode<'a> + BytesDecode<'txn>,
+        KC: BytesEncode + BytesDecode<'txn>,
         R: RangeBounds<KC::EItem>,
     {
         assert_eq!(self.env_ident, txn.txn.env.env_mut_ptr() as usize);
@@ -1794,10 +1794,10 @@ impl<KC, DC> Database<KC, DC> {
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// db.clear(&mut wtxn)?;
     ///
@@ -1844,10 +1844,10 @@ impl<KC, DC> Database<KC, DC> {
     /// # db.clear(&mut wtxn)?;
     /// // We remap the types for ease of use.
     /// let db = db.remap_types::<OwnedType<BEI32>, Str>();
-    /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
-    /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
-    /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
-    /// db.put(&mut wtxn, &BEI32::new(521), "i-am-five-hundred-and-twenty-one")?;
+    /// db.put(&mut wtxn, &BEI32::new(42), &"i-am-forty-two")?;
+    /// db.put(&mut wtxn, &BEI32::new(27), &"i-am-twenty-seven")?;
+    /// db.put(&mut wtxn, &BEI32::new(13), &"i-am-thirteen")?;
+    /// db.put(&mut wtxn, &BEI32::new(521), &"i-am-five-hundred-and-twenty-one")?;
     ///
     /// wtxn.commit()?;
     /// # Ok(()) }

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -100,6 +100,7 @@ impl EnvOpenOptions {
     }
 
     /// Set one or [more LMDB flags](http://www.lmdb.tech/doc/group__mdb__env.html).
+    ///
     /// ```
     /// use std::fs;
     /// use std::path::Path;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -121,10 +121,10 @@ impl EnvOpenOptions {
     ///
     /// // opening a write transaction
     /// let mut wtxn = env.write_txn()?;
-    /// db.put(&mut wtxn, "seven", &7)?;
-    /// db.put(&mut wtxn, "zero", &0)?;
-    /// db.put(&mut wtxn, "five", &5)?;
-    /// db.put(&mut wtxn, "three", &3)?;
+    /// db.put(&mut wtxn, &"seven", &7)?;
+    /// db.put(&mut wtxn, &"zero", &0)?;
+    /// db.put(&mut wtxn, &"five", &5)?;
+    /// db.put(&mut wtxn, &"three", &3)?;
     /// wtxn.commit()?;
     ///
     /// // Force the OS to flush the buffers (see Flags::MdbNoSync and Flags::MdbNoMetaSync).
@@ -134,10 +134,10 @@ impl EnvOpenOptions {
     /// // to check if those values are now available
     /// let mut rtxn = env.read_txn()?;
     ///
-    /// let ret = db.get(&rtxn, "zero")?;
+    /// let ret = db.get(&rtxn, &"zero")?;
     /// assert_eq!(ret, Some(0));
     ///
-    /// let ret = db.get(&rtxn, "five")?;
+    /// let ret = db.get(&rtxn, &"five")?;
     /// assert_eq!(ret, Some(5));
     /// # Ok(()) }
     /// ```
@@ -519,8 +519,8 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, "hello", "hello").unwrap();
-        db.put(&mut wtxn, "world", "world").unwrap();
+        db.put(&mut wtxn, &"hello", &"hello").unwrap();
+        db.put(&mut wtxn, &"world", &"world").unwrap();
 
         // Lets check that we can prefix_iter on that sequence with the key "255".
         let mut iter = db.iter(&wtxn).unwrap();

--- a/heed/src/iter/iter.rs
+++ b/heed/src/iter/iter.rs
@@ -112,10 +112,10 @@ impl<'txn, KC, DC> RwIter<'txn, KC, DC> {
     ///
     /// This is intended to be used when the new data is the same size as the old.
     /// Otherwise it will simply perform a delete of the old record followed by an insert.
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -126,10 +126,10 @@ impl<'txn, KC, DC> RwIter<'txn, KC, DC> {
     ///
     /// If a key is inserted that is less than any previous key a `KeyExist` error
     /// is returned and the key is not inserted into the database.
-    pub fn append<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn append(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -320,10 +320,10 @@ impl<'txn, KC, DC> RwRevIter<'txn, KC, DC> {
     ///
     /// This is intended to be used when the new data is the same size as the old.
     /// Otherwise it will simply perform a delete of the old record followed by an insert.
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -334,10 +334,10 @@ impl<'txn, KC, DC> RwRevIter<'txn, KC, DC> {
     ///
     /// If a key is inserted that is less than any previous key a `KeyExist` error
     /// is returned and the key is not inserted into the database.
-    pub fn append<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<()>
+    pub fn append(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<()>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/heed/src/iter/mod.rs
+++ b/heed/src/iter/mod.rs
@@ -39,13 +39,13 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], "world").unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], "hello").unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], "world").unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], "world").unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], &"world").unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], &"hello").unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], &"world").unwrap();
+        db.put(&mut wtxn, &&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], &"world").unwrap();
 
         // Lets check that we can prefix_iter on that sequence with the key "255".
-        let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
+        let mut iter = db.prefix_iter(&wtxn, &&[0, 0, 0, 255][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0u8, 0, 0, 255, 104, 101, 108, 108, 111][..], "hello")));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[  0, 0, 0, 255, 119, 111, 114, 108, 100][..], "world")));
         assert_eq!(iter.next().transpose().unwrap(), None);
@@ -143,23 +143,23 @@ mod tests {
         db.put(&mut wtxn, &BEI32::new(4), &()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.range(&wtxn, &(..)).unwrap();
+        let iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(4), ())));
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(4), ())));
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(4), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
@@ -168,27 +168,27 @@ mod tests {
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let range = BEI32::new(2)..=BEI32::new(4);
-        let mut iter = db.range(&wtxn, &range).unwrap();
+        let mut iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(4), ())));
 
         let range = BEI32::new(2)..BEI32::new(4);
-        let mut iter = db.range(&wtxn, &range).unwrap();
+        let mut iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(3), ())));
 
         let range = BEI32::new(2)..BEI32::new(4);
-        let mut iter = db.range(&wtxn, &range).unwrap();
+        let mut iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let range = BEI32::new(2)..BEI32::new(2);
-        let iter = db.range(&wtxn, &range).unwrap();
+        let iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let range = BEI32::new(2)..=BEI32::new(1);
-        let iter = db.range(&wtxn, &range).unwrap();
+        let iter = db.range(&wtxn, range).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         wtxn.abort().unwrap();
@@ -198,10 +198,10 @@ mod tests {
         db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.range(&wtxn, &(..)).unwrap();
+        let iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.range(&wtxn, &(..)).unwrap();
+        let mut iter = db.range(&wtxn, ..).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
@@ -224,30 +224,30 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], &()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
+        let iter = db.prefix_iter(&wtxn, &&[0, 0, 0][..]).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
 
-        let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
+        let mut iter = db.prefix_iter(&wtxn, &&[0, 0, 0][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
 
-        let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
+        let mut iter = db.prefix_iter(&wtxn, &&[0, 0, 0][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
-        let iter = db.prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
+        let iter = db.prefix_iter(&wtxn, &&[0, 0, 1][..]).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
 
-        let mut iter = db.prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
+        let mut iter = db.prefix_iter(&wtxn, &&[0, 0, 1][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
@@ -270,30 +270,30 @@ mod tests {
 
         // Create an ordered list of keys...
         let mut wtxn = env.write_txn().unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], &()).unwrap();
+        db.put(&mut wtxn, &&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], &()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
+        let iter = db.rev_prefix_iter(&wtxn, &&[0, 0, 0][..]).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
 
-        let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
+        let mut iter = db.rev_prefix_iter(&wtxn, &&[0, 0, 0][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
 
-        let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
+        let mut iter = db.rev_prefix_iter(&wtxn, &&[0, 0, 0][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
-        let iter = db.rev_prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
+        let iter = db.rev_prefix_iter(&wtxn, &&[0, 0, 1][..]).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
 
-        let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
+        let mut iter = db.rev_prefix_iter(&wtxn, &&[0, 0, 1][..]).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
@@ -324,25 +324,25 @@ mod tests {
         db.put(&mut wtxn, &BEI32::new(4), &()).unwrap();
 
         // Lets check that we properly get the last entry.
-        let iter = db.rev_range(&wtxn, &(BEI32::new(1)..=BEI32::new(3))).unwrap();
+        let iter = db.rev_range(&wtxn, BEI32::new(1)..=BEI32::new(3)).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.rev_range(&wtxn, &(BEI32::new(0)..BEI32::new(4))).unwrap();
+        let mut iter = db.rev_range(&wtxn, BEI32::new(0)..BEI32::new(4)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.rev_range(&wtxn, &(BEI32::new(0)..=BEI32::new(5))).unwrap();
+        let mut iter = db.rev_range(&wtxn, BEI32::new(0)..=BEI32::new(5)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(4), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(3), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(2), ())));
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(1), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 
-        let iter = db.rev_range(&wtxn, &(BEI32::new(0)..=BEI32::new(5))).unwrap();
+        let iter = db.rev_range(&wtxn, BEI32::new(0)..=BEI32::new(5)).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), Some((BEI32::new(1), ())));
 
-        let mut iter = db.rev_range(&wtxn, &(BEI32::new(4)..=BEI32::new(4))).unwrap();
+        let mut iter = db.rev_range(&wtxn, BEI32::new(4)..=BEI32::new(4)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((BEI32::new(4), ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
 

--- a/heed/src/iter/prefix.rs
+++ b/heed/src/iter/prefix.rs
@@ -132,10 +132,10 @@ impl<'txn, KC, DC> RwPrefix<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -346,10 +346,10 @@ impl<'txn, KC, DC> RwRevPrefix<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/heed/src/iter/range.rs
+++ b/heed/src/iter/range.rs
@@ -198,10 +198,10 @@ impl<'txn, KC, DC> RwRange<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;
@@ -462,10 +462,10 @@ impl<'txn, KC, DC> RwRevRange<'txn, KC, DC> {
         self.cursor.del_current()
     }
 
-    pub fn put_current<'a>(&mut self, key: &'a KC::EItem, data: &'a DC::EItem) -> Result<bool>
+    pub fn put_current(&mut self, key: &KC::EItem, data: &DC::EItem) -> Result<bool>
     where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
+        KC: BytesEncode,
+        DC: BytesEncode,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).ok_or(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(&data).ok_or(Error::Encoding)?;

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -29,20 +29,20 @@
 //!
 //! // opening a write transaction
 //! let mut wtxn = env.write_txn()?;
-//! db.put(&mut wtxn, "seven", &7)?;
-//! db.put(&mut wtxn, "zero", &0)?;
-//! db.put(&mut wtxn, "five", &5)?;
-//! db.put(&mut wtxn, "three", &3)?;
+//! db.put(&mut wtxn, &"seven", &7)?;
+//! db.put(&mut wtxn, &"zero", &0)?;
+//! db.put(&mut wtxn, &"five", &5)?;
+//! db.put(&mut wtxn, &"three", &3)?;
 //! wtxn.commit()?;
 //!
 //! // opening a read transaction
 //! // to check if those values are now available
 //! let mut rtxn = env.read_txn()?;
 //!
-//! let ret = db.get(&rtxn, "zero")?;
+//! let ret = db.get(&rtxn, &"zero")?;
 //! assert_eq!(ret, Some(0));
 //!
-//! let ret = db.get(&rtxn, "five")?;
+//! let ret = db.get(&rtxn, &"five")?;
 //! assert_eq!(ret, Some(5));
 //! # Ok(()) }
 //! ```
@@ -76,7 +76,7 @@ use self::mdb::ffi::{into_val, from_val};
 use std::{error, fmt, io, result};
 
 /// An helper type alias for [`Database`]s that are not typed and returns raw bytes.
-pub type UntypedDatabase = Database<types::ByteSlice, types::ByteSlice>;
+pub type UntypedDatabase = Database<types::ByteSlice<'static>, types::ByteSlice<'static>>;
 
 /// An error that encapsulates all possible errors in this crate.
 #[derive(Debug)]


### PR DESCRIPTION
We finally found a way to declare [the `BytesEncode` trait](https://github.com/Kerollmops/heed/pull/93/files#diff-86f2ad814312ee4165539d45e2d86d200b7d40f8bd0bc29d3c4112934be82b15) without making it too much complex and impossible to use in some situation where lifetimes are hard to work with, all of that by keeping the performances, and by only using stable Rust ([no nightly feature](#92)).

The only downside is the fact that structs that implement the BytesEncoder trait will be forces to declare a lifetime if the encoded item (`EItem`) requires one, and I am not quite sure that we should always accept `?Sized` `EItem` as they are impossible to be used with [ranges bounds](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html) this is the reason why the `Str` encoder now accepts a `&str` and not an `str`.

It is blocked by #91 and closes #92.