### PR TITLE
Make the `del/put_current` and `append` Cursor methods unsafe

### DIFF
--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -30,9 +30,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // We try to append ordered entries in the second database.
     let mut iter = second.iter_mut(&mut wtxn)?;
 
-    iter.append("aaaa", "lol")?;
-    iter.append("abcd", "lol")?;
-    iter.append("bcde", "lol")?;
+    unsafe { iter.append("aaaa", "lol")? };
+    unsafe { iter.append("abcd", "lol")? };
+    unsafe { iter.append("bcde", "lol")? };
 
     drop(iter);
 

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -866,12 +866,12 @@ impl PolyDatabase {
     ///
     /// let mut iter = db.iter_mut::<_, OwnedType<BEI32>, Str>(&mut wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(13), "i-am-thirteen")));
-    /// let ret = iter.del_current()?;
+    /// let ret = unsafe { iter.del_current()? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
-    /// let ret = iter.put_current(&BEI32::new(42), "i-am-the-new-forty-two")?;
+    /// let ret = unsafe { iter.put_current(&BEI32::new(42), "i-am-the-new-forty-two")? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
@@ -970,12 +970,12 @@ impl PolyDatabase {
     ///
     /// let mut iter = db.rev_iter_mut::<_, OwnedType<BEI32>, Str>(&mut wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
-    /// let ret = iter.del_current()?;
+    /// let ret = unsafe { iter.del_current()? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(13), "i-am-thirteen")));
-    /// let ret = iter.put_current(&BEI32::new(13), "i-am-the-new-thirteen")?;
+    /// let ret = unsafe { iter.put_current(&BEI32::new(13), "i-am-the-new-thirteen")? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
@@ -1110,10 +1110,10 @@ impl PolyDatabase {
     /// let range = BEI32::new(27)..=BEI32::new(42);
     /// let mut range = db.range_mut::<_, OwnedType<BEI32>, Str, _>(&mut wtxn, &range)?;
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
-    /// let ret = range.del_current()?;
+    /// let ret = unsafe { range.del_current()? };
     /// assert!(ret);
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
-    /// let ret = range.put_current(&BEI32::new(42), "i-am-the-new-forty-two")?;
+    /// let ret = unsafe { range.put_current(&BEI32::new(42), "i-am-the-new-forty-two")? };
     /// assert!(ret);
     ///
     /// assert_eq!(range.next().transpose()?, None);
@@ -1279,10 +1279,10 @@ impl PolyDatabase {
     /// let range = BEI32::new(27)..=BEI32::new(42);
     /// let mut range = db.rev_range_mut::<_, OwnedType<BEI32>, Str, _>(&mut wtxn, &range)?;
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(42), "i-am-forty-two")));
-    /// let ret = range.del_current()?;
+    /// let ret = unsafe { range.del_current()? };
     /// assert!(ret);
     /// assert_eq!(range.next().transpose()?, Some((BEI32::new(27), "i-am-twenty-seven")));
-    /// let ret = range.put_current(&BEI32::new(27), "i-am-the-new-twenty-seven")?;
+    /// let ret = unsafe { range.put_current(&BEI32::new(27), "i-am-the-new-twenty-seven")? };
     /// assert!(ret);
     ///
     /// assert_eq!(range.next().transpose()?, None);
@@ -1426,12 +1426,12 @@ impl PolyDatabase {
     ///
     /// let mut iter = db.prefix_iter_mut::<_, Str, OwnedType<BEI32>>(&mut wtxn, "i-am-twenty")?;
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-eight", BEI32::new(28))));
-    /// let ret = iter.del_current()?;
+    /// let ret = unsafe { iter.del_current()? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-nine", BEI32::new(29))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-seven", BEI32::new(27))));
-    /// let ret = iter.put_current("i-am-twenty-seven", &BEI32::new(27000))?;
+    /// let ret = unsafe { iter.put_current("i-am-twenty-seven", &BEI32::new(27000))? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
@@ -1551,12 +1551,12 @@ impl PolyDatabase {
     ///
     /// let mut iter = db.rev_prefix_iter_mut::<_, Str, OwnedType<BEI32>>(&mut wtxn, "i-am-twenty")?;
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-seven", BEI32::new(27))));
-    /// let ret = iter.del_current()?;
+    /// let ret = unsafe { iter.del_current()? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-nine", BEI32::new(29))));
     /// assert_eq!(iter.next().transpose()?, Some(("i-am-twenty-eight", BEI32::new(28))));
-    /// let ret = iter.put_current("i-am-twenty-eight", &BEI32::new(28000))?;
+    /// let ret = unsafe { iter.put_current("i-am-twenty-eight", &BEI32::new(28000))? };
     /// assert!(ret);
     ///
     /// assert_eq!(iter.next().transpose()?, None);
@@ -1823,7 +1823,6 @@ impl PolyDatabase {
     /// let range = BEI32::new(27)..=BEI32::new(42);
     /// let ret = db.delete_range::<_, OwnedType<BEI32>, _>(&mut wtxn, &range)?;
     /// assert_eq!(ret, 2);
-    ///
     ///
     /// let mut iter = db.iter::<_, OwnedType<BEI32>, Str>(&wtxn)?;
     /// assert_eq!(iter.next().transpose()?, Some((BEI32::new(13), "i-am-thirteen")));


### PR DESCRIPTION
This PR emerges from [a bug that we found in the milli repository](https://github.com/meilisearch/milli/issues/261), an undefined behavior due to a bad usage of LMDB. We were keeping borrowed data from an LMDB database while modifying it by using `put_current` at the same time, this is prohibited!

> Values returned from the database are valid only until a subsequent update operation, or the end of the transaction.

In this PR we simply declare the `del_current`, `put_current`, and `append` iterator methods as unsafe and improved the documentation of them by introducing a _Safety_ paragraph explaining the safe way to use these methods. The right way to use these methods is to just `to_owned` the key and value from the database before using this method.