### PR TITLE
Use an up-to-date lmdb-sys dependency

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = { version = "1.3.4", default-features = false }
 heed-traits = { version = "0.7.0", path = "../heed-traits" }
 heed-types = { version = "0.7.2", path = "../heed-types" }
 libc = "0.2.80"
-lmdb-rkv-sys = { version = "0.11.0", optional = true }
+lmdb-rkv-sys = { git = "https://github.com/meilisearch/lmdb-rs", optional = true }
 mdbx-sys = { version = "0.7.1", optional = true }
 once_cell = "1.5.2"
 page_size = "0.4.2"


### PR DESCRIPTION
We want to use the latest version of LMDB so we decided to fork Mozilla's repository and bump the version of LMDB. It is a breaking change.

We will be able to publish a new version of heed (v0.12.0) when [a version of lmdb-rkv-sys is published on crates.io](https://github.com/meilisearch/lmdb-rs/pull/2).