### PR TITLE
Introduce the new `AlwaysFreePages` flag

### DIFF
--- a/heed/src/mdb/lmdb_flags.rs
+++ b/heed/src/mdb/lmdb_flags.rs
@@ -12,4 +12,6 @@ pub enum Flags {
     MdbNoLock = lmdb_sys::MDB_NOLOCK,
     MdbNoRdAhead = lmdb_sys::MDB_NORDAHEAD,
     MdbNoMemInit = lmdb_sys::MDB_NOMEMINIT,
+    /// Always free single pages instead of keeping them in a list, for future reuse.
+    MdbAlwaysFreePages = lmdb_sys::MDB_ALWAYSFREEPAGES,
 }


### PR DESCRIPTION
This PR introduces the new `AlwaysFreePages` flag into the enum `Flags` variants. This flag makes sure that LMDB always free the single pages it uses before writing on the disk. It reduces the amount of memory kept (leaked) after a massive write into the database.