### PR TITLE
disable rust fmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
disable rustfmt for the project. Note that this is still only available with v1.4.38, that is not shipped with the current stable toolchain (it should be with the next, next week)
